### PR TITLE
updated gradle for directly running the code after cloing the repo

### DIFF
--- a/source-code/app/app.iml
+++ b/source-code/app/app.iml
@@ -36,13 +36,13 @@
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/debug" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/debug" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/generated/androidTest/debug" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/resources" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/debug/assets" type="java-resource" />
@@ -65,18 +65,15 @@
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/coverage-instrumented-classes" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.afollestad/material-dialogs/0.7.4.2/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/22.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.1.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/cardview-v7/21.0.3/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/22.1.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/22.1.1/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.cocosw/bottomsheet/1.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.1.1/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.cocosw/bottomsheet/1.2.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/answers/1.2.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/beta/1.1.2/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.crashlytics.sdk.android/crashlytics-core/2.3.1/jars" />
@@ -84,24 +81,22 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.daimajia.androidanimations/library/1.1.3/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.daimajia.easing/library/1.0.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.getbase/floatingactionbutton/1.9.0/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.github.afollestad.material-dialogs/commons/0.8.5.3/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.github.afollestad.material-dialogs/core/0.8.5.3/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.viewpagerindicator/library/2.4.1/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/io.fabric.sdk.android/fabric/1.3.2/jars" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/me.zhanghai.android.materialprogressbar/library/1.1.4/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/libs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/ndk" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/proguard" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
-    <orderEntry type="jdk" jdkName="Android API 22 Platform" jdkType="Android SDK" />
+    <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="floatingactionbutton-1.9.0" level="project" />
     <orderEntry type="library" exported="" name="zipsigner-lib-1.17" level="project" />
@@ -111,23 +106,25 @@
     <orderEntry type="library" exported="" name="cardview-v7-21.0.3" level="project" />
     <orderEntry type="library" exported="" name="kellinwood-logging-log4j-1.0" level="project" />
     <orderEntry type="library" exported="" name="pkix-1.51.0.0" level="project" />
-    <orderEntry type="library" exported="" name="material-dialogs-0.7.4.2" level="project" />
+    <orderEntry type="library" exported="" name="appcompat-v7-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="fabric-1.3.2" level="project" />
     <orderEntry type="library" exported="" name="core-1.51.0.0" level="project" />
     <orderEntry type="library" exported="" name="prov-1.51.0.0" level="project" />
     <orderEntry type="library" exported="" name="library-2.4.0" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-22.1.1" level="project" />
     <orderEntry type="library" exported="" name="library-2.4.1" level="project" />
     <orderEntry type="library" exported="" name="library-1.0.1" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="bottomsheet-1.2.0" level="project" />
+    <orderEntry type="library" exported="" name="core-0.8.5.3" level="project" />
     <orderEntry type="library" exported="" name="kellinwood-logging-lib-1.1" level="project" />
     <orderEntry type="library" exported="" name="kellinwood-logging-android-1.4" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-22.1.1" level="project" />
-    <orderEntry type="library" exported="" name="bottomsheet-1.1.1" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-22.1.1" level="project" />
     <orderEntry type="library" exported="" name="beta-1.1.2" level="project" />
+    <orderEntry type="library" exported="" name="recyclerview-v7-23.1.1" level="project" />
+    <orderEntry type="library" exported="" name="support-v4-23.1.1" level="project" />
     <orderEntry type="library" exported="" name="library-1.1.3" level="project" />
+    <orderEntry type="library" exported="" name="commons-0.8.5.3" level="project" />
     <orderEntry type="library" exported="" name="zipio-lib-1.8" level="project" />
     <orderEntry type="library" exported="" name="crashlytics-2.3.1" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-22.1.1" level="project" />
+    <orderEntry type="library" exported="" name="library-1.1.4" level="project" />
   </component>
 </module>

--- a/source-code/app/build.gradle
+++ b/source-code/app/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'io.fabric.tools:gradle:1.+'
+        classpath 'io.fabric.tools:gradle:1.19.2'
     }
 }
 apply plugin: 'com.android.application'
@@ -24,12 +24,12 @@ android {
             storePassword 'buildmlearn'
         }
     }
-    compileSdkVersion 22
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.1"
     defaultConfig {
         applicationId "org.buildmlearn.toolkit"
         minSdkVersion 14
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }
@@ -50,7 +50,13 @@ dependencies {
     compile 'com.android.support:cardview-v7:21.0.+'
     compile 'com.android.support:recyclerview-v7:21.0.+'
     compile 'com.getbase:floatingactionbutton:1.9.0'
-    compile 'com.afollestad:material-dialogs:0.7.4.2'
+//    compile 'com.afollestad:material-dialogs:0.7.4.2'
+    compile('com.github.afollestad.material-dialogs:core:0.8.5.3@aar') {
+        transitive = true
+    }
+    compile('com.github.afollestad.material-dialogs:commons:0.8.5.3@aar') {
+        transitive = true
+    }
     compile 'com.cocosw:bottomsheet:1.+@aar'
     compile('com.crashlytics.sdk.android:crashlytics:2.3.1@aar') {
         transitive = true;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.res.ColorStateList;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Build;
@@ -25,7 +26,7 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
-import com.afollestad.materialdialogs.ThemeSingleton;
+import com.afollestad.materialdialogs.internal.ThemeSingleton;
 import com.cocosw.bottomsheet.BottomSheet;
 
 import org.buildmlearn.toolkit.R;
@@ -442,9 +443,9 @@ public class TemplateEditor extends AppCompatActivity {
         int primaryColor = getResources().getColor(R.color.color_primary_dark);
         int primaryColorDark = getResources().getColor(R.color.color_selected_dark);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(primaryColor));
-        ThemeSingleton.get().positiveColor = primaryColor;
-        ThemeSingleton.get().neutralColor = primaryColor;
-        ThemeSingleton.get().negativeColor = primaryColor;
+        ThemeSingleton.get().positiveColor = ColorStateList.valueOf(primaryColor);
+        ThemeSingleton.get().neutralColor = ColorStateList.valueOf(primaryColor);
+        ThemeSingleton.get().negativeColor = ColorStateList.valueOf(primaryColor);
         ThemeSingleton.get().widgetColor = primaryColor;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             getWindow().setStatusBarColor(primaryColorDark);
@@ -464,9 +465,9 @@ public class TemplateEditor extends AppCompatActivity {
         int primaryColor = getResources().getColor(R.color.color_primary);
         int primaryColorDark = getResources().getColor(R.color.color_primary_dark);
         getSupportActionBar().setBackgroundDrawable(new ColorDrawable(primaryColor));
-        ThemeSingleton.get().positiveColor = primaryColor;
-        ThemeSingleton.get().neutralColor = primaryColor;
-        ThemeSingleton.get().negativeColor = primaryColor;
+        ThemeSingleton.get().positiveColor = ColorStateList.valueOf(primaryColor);
+        ThemeSingleton.get().neutralColor = ColorStateList.valueOf(primaryColor);
+        ThemeSingleton.get().negativeColor = ColorStateList.valueOf(primaryColor);
         ThemeSingleton.get().widgetColor = primaryColor;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             getWindow().setStatusBarColor(primaryColorDark);

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/FlashCardAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/FlashCardAdapter.java
@@ -13,6 +13,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.activity.TemplateEditor;
 import org.buildmlearn.toolkit.views.TextViewPlus;
 
 import java.util.ArrayList;
@@ -101,6 +102,8 @@ public class FlashCardAdapter extends BaseAdapter {
                         mData.remove(position);
                         notifyDataSetChanged();
                         dialog.dismiss();
+
+                        ((TemplateEditor) mContext).restoreSelectedView();
                     }
                 });
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/InfoAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/InfoAdapter.java
@@ -12,13 +12,14 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.activity.TemplateEditor;
 import org.buildmlearn.toolkit.views.TextViewPlus;
 
 import java.util.ArrayList;
 
 /**
  * @brief Adapter for displaying Info Template Editor data.
- *
+ * <p/>
  * Created by abhishek on 17/06/15 at 9:48 PM.
  */
 public class InfoAdapter extends BaseAdapter {
@@ -86,6 +87,8 @@ public class InfoAdapter extends BaseAdapter {
                         data.remove(position);
                         notifyDataSetChanged();
                         dialog.dismiss();
+
+                        ((TemplateEditor) mContext).restoreSelectedView();
                     }
                 });
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingAdapter.java
@@ -12,6 +12,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.activity.TemplateEditor;
 import org.buildmlearn.toolkit.views.TextViewPlus;
 
 import java.util.ArrayList;
@@ -86,6 +87,8 @@ public class LearnSpellingAdapter extends BaseAdapter {
                         data.remove(position);
                         notifyDataSetChanged();
                         dialog.dismiss();
+
+                        ((TemplateEditor) mContext).restoreSelectedView();
                     }
                 });
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/QuizAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/QuizAdapter.java
@@ -16,13 +16,14 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.activity.TemplateEditor;
 import org.buildmlearn.toolkit.views.TextViewPlus;
 
 import java.util.ArrayList;
 
 /**
  * @brief Adapter for displaying Quiz Template Editor data.
- *
+ * <p/>
  * Created by abhishek on 28/5/15.
  */
 public class QuizAdapter extends BaseAdapter {
@@ -139,6 +140,8 @@ public class QuizAdapter extends BaseAdapter {
                         quizData.remove(position);
                         notifyDataSetChanged();
                         dialog.dismiss();
+
+                        ((TemplateEditor) context).restoreSelectedView();
                     }
                 });
 

--- a/source-code/build.gradle
+++ b/source-code/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -17,5 +18,6 @@ allprojects {
         maven { url "http://dl.bintray.com/populov/maven" }
         jcenter()
         mavenCentral()
+        maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
Commit 1 -  (@5c9cc5025a3236457383b533583bc9608182d9c3) : It took me a lot of time in resolving errors due to my support library version being 23,which is latest version whereas the repo is not directly usable with version 23, it gives errors about resource files..

I have made changes to make code compliant with support library version 23, and also updated gradle versions and other gradle related things.

Also, the material dialog library was giving error in gradle sync since it is no longer available through that link.Hence I updated material dialog library gradle version.(jitpack was added due to the new version of material dialog library)

In new version , com.afollestad.materialdialogs.ThemeSingleton was not present. Instead it was moved to com.afollestad.materialdialogs.internal.ThemeSingleton and had minor changes as well which are reflected in TemplateEditor class.