### PR TITLE
Fix plugin version

### DIFF
--- a/source-code/build.gradle
+++ b/source-code/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-alpha3'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
To solve Android Studio error (Plugin is too old, please update to a more recent version).