### PR TITLE
Implemented Restore Project from APK

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
@@ -212,6 +212,7 @@ public class TemplateEditor extends AppCompatActivity {
         try {
             Object templateObject = templateClass.newInstance();
             selectedTemplate = (TemplateInterface) templateObject;
+            selectedTemplate.setTemplateId(templateId);
             populateListView(selectedTemplate.newTemplateEditorAdapter(this));
             setUpActionBar();
         } catch (InstantiationException e) {
@@ -315,7 +316,7 @@ public class TemplateEditor extends AppCompatActivity {
                                 String aliasName = getString(R.string.alias_name);
                                 String aliaspassword = getString(R.string.alias_password);
                                 KeyStoreDetails keyStoreDetails = new KeyStoreDetails("TestKeyStore.jks", keyPassword, aliasName, aliaspassword);
-                                SignerThread signer = new SignerThread(getApplicationContext(), selectedTemplate.getApkFilePath(), saveProject(), keyStoreDetails, selectedTemplate.getAssetsFilePath(), selectedTemplate.getAssetsFileName());
+                                SignerThread signer = new SignerThread(getApplicationContext(), selectedTemplate.getApkFilePath(), saveProject(), keyStoreDetails, selectedTemplate.getAssetsFilePath(), selectedTemplate.getAssetsFileName(TemplateEditor.this));
 
                                 mApkGenerationDialog = new MaterialDialog.Builder(TemplateEditor.this)
                                         .title(R.string.apk_progress_dialog)
@@ -374,7 +375,7 @@ public class TemplateEditor extends AppCompatActivity {
                                 aliasName = getString(R.string.alias_name);
                                 aliaspassword = getString(R.string.alias_password);
                                 keyStoreDetails = new KeyStoreDetails("TestKeyStore.jks", keyPassword, aliasName, aliaspassword);
-                                signer = new SignerThread(getApplicationContext(), selectedTemplate.getApkFilePath(), saveProject(), keyStoreDetails, selectedTemplate.getAssetsFilePath(), selectedTemplate.getAssetsFileName());
+                                signer = new SignerThread(getApplicationContext(), selectedTemplate.getApkFilePath(), saveProject(), keyStoreDetails, selectedTemplate.getAssetsFilePath(), selectedTemplate.getAssetsFileName(TemplateEditor.this));
 
                                 mApkGenerationDialog = new MaterialDialog.Builder(TemplateEditor.this)
                                         .title(R.string.apk_progress_dialog)

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
@@ -1,13 +1,25 @@
 package org.buildmlearn.toolkit.fragment;
 
+import android.app.Activity;
+import android.content.Intent;
 import android.content.SharedPreferences;
+import android.net.Uri;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.widget.Toast;
 
+import com.afollestad.materialdialogs.MaterialDialog;
+
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.activity.DeepLinkerActivity;
+import org.buildmlearn.toolkit.utilities.RestoreThread;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
 
 /**
  * Created by abhishek on 21/06/15 at 9:51 PM.
@@ -17,17 +29,28 @@ public class SettingsFragment extends PreferenceFragment {
     private Preference prefUsername;
     private SharedPreferences preferences;
 
+    private static final int REQUEST_PICK_APK = 9985;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         addPreferencesFromResource(R.xml.fragment_settings);
         preferences = PreferenceManager.getDefaultSharedPreferences(getActivity());
 
-        Preference button = findPreference(getString(R.string.key_delete_temporary_files));
-        button.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        Preference deleteTempFiles = findPreference(getString(R.string.key_delete_temporary_files));
+        deleteTempFiles.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 Toast.makeText(SettingsFragment.this.getActivity(), "Deleting temp files", Toast.LENGTH_SHORT).show();
+                return true;
+            }
+        });
+
+        Preference restoreProject = findPreference(getString(R.string.key_restore_project));
+        restoreProject.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                initRestoreProjectDialog();
                 return true;
             }
         });
@@ -39,5 +62,74 @@ public class SettingsFragment extends PreferenceFragment {
     public void onResume() {
         super.onResume();
         prefUsername.setSummary(preferences.getString(getString(R.string.key_user_name), ""));
+    }
+
+    void initRestoreProjectDialog() {
+        Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+        intent.setType("application/*");
+        startActivityForResult(intent, REQUEST_PICK_APK);
+    }
+
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        switch (requestCode) {
+            case REQUEST_PICK_APK :
+
+                if (resultCode == Activity.RESULT_OK) {
+
+                    try {
+                        final MaterialDialog processDiaglog = new MaterialDialog.Builder(getActivity())
+                                .title(R.string.restore_progress_dialog)
+                                .content(R.string.restore_msg)
+                                .cancelable(false)
+                                .progress(true, 0)
+                                .show();
+
+
+                        InputStream inputStream = getActivity().getContentResolver().openInputStream(data.getData());
+                        RestoreThread restore = new RestoreThread(getActivity(), inputStream);
+
+                        restore.setRestoreListener(new RestoreThread.OnRestoreComplete() {
+                            @Override
+                            public void onSuccess(File assetFile) {
+                                processDiaglog.dismiss();
+                                Intent intentProject = new Intent(getActivity(), DeepLinkerActivity.class);
+                                intentProject.setData(Uri.fromFile(assetFile));
+                                getActivity().startActivity(intentProject);
+                            }
+
+                            @Override
+                            public void onFail(Exception e) {
+                                processDiaglog.dismiss();
+                                final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+                                        .title(R.string.dialog_restore_title)
+                                        .content(R.string.dialog_restore_failed)
+                                        .positiveText(R.string.OkButtonLabel)
+                                        .build();
+                                dialog.show();
+                            }
+                        });
+
+                        restore.start();
+
+                    } catch (FileNotFoundException e) {
+                        e.printStackTrace();
+
+                        final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+                                .title(R.string.dialog_restore_title)
+                                .content(R.string.dialog_restore_fileerror)
+                                .positiveText(R.string.OkButtonLabel)
+                                .build();
+                        dialog.show();
+                    }
+
+
+                }
+
+                break;
+        }
+
     }
 }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/model/Template.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/model/Template.java
@@ -16,10 +16,10 @@ import org.buildmlearn.toolkit.templates.QuizTemplate;
  */
 public enum Template {
 
-    BASIC_M_LEARNING(R.string.basic_m_learning_title, R.string.basic_m_learning_description, R.drawable.basic_m_learning, R.string.info_template, InfoTemplate.class),
-    LEARN_SPELLING(R.string.learn_spellings_title, R.string.learn_spellings_description, R.drawable.basic_m_learning, R.string.spelling_type, LearnSpellingTemplate.class),
-    QUIZ(R.string.quiz_title, R.string.quiz_description, R.drawable.basic_m_learning, R.string.quiz_type, QuizTemplate.class),
-    FLASH_CARD(R.string.flash_card_title, R.string.flash_card_description, R.drawable.basic_m_learning, R.string.flash_card_template, FlashTemplate.class);
+    BASIC_M_LEARNING(R.string.basic_m_learning_title, R.string.basic_m_learning_description, R.drawable.basic_m_learning, R.string.info_template, InfoTemplate.class, R.string.info_assets_name),
+    LEARN_SPELLING(R.string.learn_spellings_title, R.string.learn_spellings_description, R.drawable.basic_m_learning, R.string.spelling_type, LearnSpellingTemplate.class, R.string.spelling_assets_name),
+    QUIZ(R.string.quiz_title, R.string.quiz_description, R.drawable.basic_m_learning, R.string.quiz_type, QuizTemplate.class, R.string.quiz_assets_name),
+    FLASH_CARD(R.string.flash_card_title, R.string.flash_card_description, R.drawable.basic_m_learning, R.string.flash_card_template, FlashTemplate.class, R.string.flash_assets_name);
 
     @StringRes
     int type;
@@ -33,13 +33,17 @@ public enum Template {
     @StringRes
     int description;
     private Class<? extends TemplateInterface> templateClass;
+    private
+    @StringRes
+    int assetsName;
 
-    Template(@StringRes int title, @StringRes int description, @DrawableRes int image, @StringRes int type, Class<? extends TemplateInterface> templateClass) {
+    Template(@StringRes int title, @StringRes int description, @DrawableRes int image, @StringRes int type, Class<? extends TemplateInterface> templateClass, @StringRes int assetsName) {
         this.image = image;
         this.title = title;
         this.description = description;
         this.type = type;
         this.templateClass = templateClass;
+        this.assetsName = assetsName;
     }
 
     public int getImage() {
@@ -60,5 +64,9 @@ public enum Template {
 
     public int getType() {
         return type;
+    }
+
+    public int getAssetsName() {
+        return assetsName;
     }
 }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/model/TemplateInterface.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/model/TemplateInterface.java
@@ -43,6 +43,11 @@ public interface TemplateInterface extends Serializable {
     String onAttach();
 
     /**
+     * @brief Set templateId,that can be used to get Info about current template from enum Template
+     * @param templateId
+     */
+    void setTemplateId(int templateId);
+    /**
      * @return Title as a string
      * @brief Used to get the title of the templaye. Mainly used to update ActionBar in Template Editor
      */
@@ -81,10 +86,11 @@ public interface TemplateInterface extends Serializable {
     Fragment getSimulatorFragment(String filePathWithName);
 
     /**
+     * @param context For obtaining String from StringRes
      * @return Asset file name
      * @brief Name of the xml file congaing template data in the assets folders in the build apk.
      */
-    String getAssetsFileName();
+     String getAssetsFileName(Context context);
 
     /**
      * @return Assets folder path

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/FlashTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/FlashTemplate.java
@@ -24,6 +24,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.ToolkitApplication;
 import org.buildmlearn.toolkit.flashcardtemplate.StartFragment;
+import org.buildmlearn.toolkit.model.Template;
 import org.buildmlearn.toolkit.model.TemplateInterface;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -46,6 +47,7 @@ public class FlashTemplate implements TemplateInterface {
     transient private ImageView mBannerImage;
     private boolean mIsPhotoAttached;
     transient private FlashCardAdapter mAdapter;
+    private int templateId;
 
     public FlashTemplate() {
         mData = new ArrayList<>();
@@ -82,6 +84,11 @@ public class FlashTemplate implements TemplateInterface {
     @Override
     public String onAttach() {
         return "Flash card template";
+    }
+
+    @Override
+    public void setTemplateId(int templateId) {
+        this.templateId = templateId;
     }
 
     @Override
@@ -265,8 +272,9 @@ public class FlashTemplate implements TemplateInterface {
     }
 
     @Override
-    public String getAssetsFileName() {
-        return "flash_content.xml";
+    public String getAssetsFileName(Context context) {
+        Template[] templates = Template.values();
+        return  context.getString(templates[templateId].getAssetsName());
     }
 
     @Override

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/InfoTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/InfoTemplate.java
@@ -14,6 +14,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.infotemplate.TFTFragment;
+import org.buildmlearn.toolkit.model.Template;
 import org.buildmlearn.toolkit.model.TemplateInterface;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -29,6 +30,7 @@ public class InfoTemplate implements TemplateInterface {
 
     transient private InfoAdapter adapter;
     private ArrayList<InfoModel> infoData;
+    private int templateId;
 
     public InfoTemplate() {
         infoData = new ArrayList<>();
@@ -79,6 +81,11 @@ public class InfoTemplate implements TemplateInterface {
     @Override
     public String onAttach() {
         return "Info Template";
+    }
+
+    @Override
+    public void setTemplateId(int templateId) {
+        this.templateId = templateId;
     }
 
     @Override
@@ -186,8 +193,9 @@ public class InfoTemplate implements TemplateInterface {
     }
 
     @Override
-    public String getAssetsFileName() {
-        return "info_content.xml";
+    public String getAssetsFileName(Context context) {
+        Template[] templates = Template.values();
+        return  context.getString(templates[templateId].getAssetsName());
     }
 
     @Override

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingTemplate.java
@@ -14,6 +14,7 @@ import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.learnspelling.SpellingMainFragment;
+import org.buildmlearn.toolkit.model.Template;
 import org.buildmlearn.toolkit.model.TemplateInterface;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -29,6 +30,7 @@ public class LearnSpellingTemplate implements TemplateInterface {
 
     transient private LearnSpellingAdapter adapter;
     private ArrayList<LearnSpellingModel> mLearnSpellingData;
+    private int templateId;
 
     public LearnSpellingTemplate() {
         mLearnSpellingData = new ArrayList<>();
@@ -79,6 +81,11 @@ public class LearnSpellingTemplate implements TemplateInterface {
     @Override
     public String onAttach() {
         return "Learn Spelling Template";
+    }
+
+    @Override
+    public void setTemplateId(int templateId) {
+        this.templateId = templateId;
     }
 
     @Override
@@ -186,8 +193,9 @@ public class LearnSpellingTemplate implements TemplateInterface {
     }
 
     @Override
-    public String getAssetsFileName() {
-        return "spelling_content.xml";
+    public String getAssetsFileName(Context context) {
+        Template[] templates = Template.values();
+        return  context.getString(templates[templateId].getAssetsName());
     }
 
     @Override

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/QuizTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/QuizTemplate.java
@@ -14,6 +14,7 @@ import com.afollestad.materialdialogs.DialogAction;
 import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
+import org.buildmlearn.toolkit.model.Template;
 import org.buildmlearn.toolkit.model.TemplateInterface;
 import org.buildmlearn.toolkit.quiztemplate.TFTQuizFragment;
 import org.w3c.dom.Document;
@@ -32,6 +33,7 @@ public class QuizTemplate implements TemplateInterface {
 
     transient private QuizAdapter mAdapter;
     private ArrayList<QuizModel> quizData;
+    private int templateId;
 
     public QuizTemplate() {
         this.quizData = new ArrayList<>();
@@ -69,6 +71,11 @@ public class QuizTemplate implements TemplateInterface {
     @Override
     public String onAttach() {
         return "Quiz Template";
+    }
+
+    @Override
+    public void setTemplateId(int templateId) {
+        this.templateId = templateId;
     }
 
     @Override
@@ -271,8 +278,9 @@ public class QuizTemplate implements TemplateInterface {
     }
 
     @Override
-    public String getAssetsFileName() {
-        return "quiz_content.xml";
+    public String getAssetsFileName(Context context) {
+        Template[] templates = Template.values();
+        return  context.getString(templates[templateId].getAssetsName());
     }
 
     @Override

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/FileUtils.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/FileUtils.java
@@ -46,6 +46,18 @@ public class FileUtils {
      * @throws IOException Exception thrown in case of some error.
      */
     public static void unZip(String zipFilePath, String destinationFolder) throws IOException {
+        InputStream zipInputStream = new FileInputStream(zipFilePath);
+        unZip(zipInputStream, destinationFolder);
+    }
+
+    /**
+     * @brief Unzips a compressed file (.zip, .apk)
+     *
+     * @param zipInputStream InputStream of Zip file
+     * @param destinationFolder Destination folder for stroing the uncompresses files.
+     * @throws IOException Exception thrown in case of some error.
+     */
+    public static void unZip(InputStream zipInputStream, String destinationFolder) throws IOException {
         int size;
         byte[] buffer = new byte[BUFFER_SIZE];
         try {
@@ -57,7 +69,7 @@ public class FileUtils {
                 f.mkdirs();
             }
 
-            ZipInputStream zin = new ZipInputStream(new BufferedInputStream(new FileInputStream(zipFilePath), BUFFER_SIZE));
+            ZipInputStream zin = new ZipInputStream(new BufferedInputStream(zipInputStream, BUFFER_SIZE));
             try {
                 ZipEntry ze;
                 while ((ze = zin.getNextEntry()) != null) {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
@@ -1,0 +1,105 @@
+package org.buildmlearn.toolkit.utilities;
+
+/**
+ * Created by scopeinfinity on 14/3/16.
+ */
+
+
+import android.content.Context;
+
+import org.buildmlearn.toolkit.ToolkitApplication;
+import org.buildmlearn.toolkit.model.Template;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * @brief Class for extracting .buildmlearn file from apk.
+ */
+public class RestoreThread extends Thread {
+    private static final String TAG = "RestoreThread";
+    private static final String TEMP_FOLDER = "rtf";
+    private String assetFileName;
+    private static String assetDirectory = "assets";
+
+
+    private Context context;
+    private InputStream zipInputStream;
+    private ToolkitApplication toolkit;
+
+    private OnRestoreComplete listener;
+
+    public RestoreThread(Context context, InputStream zipInputStream) {
+        this.context = context;
+        this.zipInputStream = zipInputStream;
+        toolkit = (ToolkitApplication) context.getApplicationContext();
+    }
+
+    public void setRestoreListener(OnRestoreComplete listener) {
+        this.listener = listener;
+    }
+
+    @Override
+    public void run() {
+        try {
+            File assetDir = new File( toolkit.getUnZipDir() + TEMP_FOLDER+"/"+assetDirectory);
+            assetDir.mkdirs();
+            //Deleting Previous Files if Exists
+            File[] templateAssets = assetDir.listFiles();
+            for (File data:templateAssets  ) {
+                data.delete();
+            }
+
+            //Unzipping
+            FileUtils.unZip(zipInputStream, toolkit.getUnZipDir() + TEMP_FOLDER);
+            String files[] = assetDir.list();
+            File data = null;
+            Template[] templates = Template.values();
+
+            //Search if asset have required file
+            for (String file:files) {
+                boolean matchFound = false;
+                for (Template template :templates)
+
+                if(context.getString(template.getAssetsName()).equals(file)) {
+                    data = new File(assetDir,file); //*_content.xml File
+                    matchFound = true;
+                    break;
+                }
+                if (matchFound)
+                    break;
+            }
+
+            if (data == null) {
+                if (listener!=null)
+                    listener.onFail(new Exception("Assets Data not Found!"));
+                return;
+            }
+
+            if (listener!=null)
+                listener.onSuccess(data);
+
+
+        } catch (IOException e) {
+            if (listener != null) {
+                listener.onFail(e);
+            }
+            e.printStackTrace();
+        } finally {
+
+            try {
+                zipInputStream.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+    }
+
+    public interface OnRestoreComplete {
+        void onSuccess(File assetFile);
+
+        void onFail(Exception e);
+    }
+}

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
@@ -61,6 +61,7 @@ public class SignerThread extends Thread {
 
     public void run() {
 
+
         FileUtils.copyAssets(context, assetsApk, toolkit.getApkDir());
         FileUtils.copyAssets(context, keyDetails.getAssetsPath(), toolkit.getApkDir());
 
@@ -77,6 +78,11 @@ public class SignerThread extends Thread {
         boolean success = true;
         if (!folder.exists()) {
             success = folder.mkdir();
+        } else {
+            //Empty the folder, clean previous assets
+            File[] oldAssets = folder.listFiles();
+            for (File file:oldAssets )
+                file.delete();
         }
 
         File src = new File(projectFile);

--- a/source-code/app/src/main/res/values/strings.xml
+++ b/source-code/app/src/main/res/values/strings.xml
@@ -25,6 +25,12 @@
     <string name="no_item">No items</string>
     <string name="add_item_help">Click Add button to start adding items</string>
 
+    <!-- Restore Dialog-->
+
+    <string name="dialog_restore_title">Restore Project</string>
+    <string name="dialog_restore_failed">Unable to restore Project from given apk</string>
+    <string name="dialog_restore_fileerror">Unable to load given apk</string>
+
     <!-- Quiz Template-->
 
     <string name="dialog_yes">Yes</string>
@@ -97,6 +103,12 @@
     <string name="high">High</string>
     <string name="speech_rate">Speech Rate:</string>
 
+    <!-- Assets Filename -->
+    <string name="spelling_assets_name">spelling_content.xml</string>
+    <string name="quiz_assets_name">quiz_content.xml</string>
+    <string name="flash_assets_name">flash_content.xml</string>
+    <string name="info_assets_name">info_content.xml</string>
+
     <!-- Template Resources-->
     <string name="basic_m_learning_title">Basic mLearning</string>
     <string name="basic_m_learning_description">Create app displaying clickable list of textual information</string>
@@ -107,6 +119,7 @@
     <string name="learn_spellings_title">Learn Spellings</string>
     <string name="learn_spellings_description">Choose this template to create applications for learning to spell words</string>
     <string name="spelling_type">SpellingTemplate</string>
+
 
     <string name="quiz_title">Quiz</string>
     <string name="quiz_new_question_title">Add New Question</string>
@@ -356,10 +369,15 @@
     <string name="delete_temp_files">Delete Temporary Files</string>
     <string name="summary_temp_files">Delete temporary generated files to save storage space</string>
 
+    <string name="key_restore_project">restore_project</string>
+    <string name="restore_project">Restore Project</string>
+    <string name="summary_restore_project">Restore Project back from apk</string>
+
     <string name="key_user_name">key_user_name</string>
     <string name="your_name">Your Name</string>
     <string name="summary_name">Your name will be used as default author name</string>
     <string name="app_settings">App Settings</string>
+    <string name="advance_settings">Advance Settings</string>
 
     <string name="main_title">BuildmLearn</string>
     <string name="main_subtitle">Toolkit</string>
@@ -417,5 +435,7 @@
     </string-array>
     <string name="title_activity_upload">Upload Application</string>
     <string name="apk_progress_dialog">Generating Apk</string>
+    <string name="restore_progress_dialog">Restoring</string>
     <string name="apk_msg">Inserting data into Apk</string>
+    <string name="restore_msg">Restoring data from Apk</string>
 </resources>

--- a/source-code/app/src/main/res/xml/fragment_settings.xml
+++ b/source-code/app/src/main/res/xml/fragment_settings.xml
@@ -28,4 +28,13 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/advance_settings">
+
+        <Preference
+            android:key="@string/key_restore_project"
+            android:summary="@string/summary_restore_project"
+            android:title="@string/restore_project" />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>


### PR DESCRIPTION
Clean Assets before inserting `*_content.xml` into asset directory during APK export.
    Fixes : Unnecessarily coping of `*_content.xml` from previous project to new APK.

Implemented Restore Option
    Getting back .buildmlearn file as a project from Previously generated APK

![GIF](https://cloud.githubusercontent.com/assets/9819066/13741280/7444e328-e9fb-11e5-999d-50d8c360552e.gif)
