### PR TITLE
Spelling issue #101 resolved. 

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/SpellingActivity.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/SpellingActivity.java
@@ -190,7 +190,7 @@ public class SpellingActivity extends Fragment implements
         } else {
             mAlert.dismiss();
             boolean isCorrect = false;
-            if (mEt_Spelling.getText().toString()
+            if (mEt_Spelling.getText().toString().trim()
                     .equalsIgnoreCase(mWordList.get(count).getWord())) {
                 isCorrect = true;
                 mManager.incrementCorrect();

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/LearnSpellingTemplate.java
@@ -104,8 +104,8 @@ public class LearnSpellingTemplate implements TemplateInterface {
             public void onClick(View v) {
 
                 if (validated(activity, word, meaning)) {
-                    String wordText = word.getText().toString();
-                    String meaningText = meaning.getText().toString();
+                    String wordText = word.getText().toString().trim();
+                    String meaningText = meaning.getText().toString().trim();
 
                     LearnSpellingModel temp = new LearnSpellingModel(wordText, meaningText);
                     mLearnSpellingData.add(temp);


### PR DESCRIPTION
its was due to an extra space which can be inserted (by user/autocorrect)at the beging or the end of the word when the word is to be save it causes the word to have the space and when checked with the answered (which may or may not contain space at exact location as in saved word) word it reurns false there fore triming the word at saving time and when getting the andwer from user