### PR TITLE
load only buildmlearn generated apks

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
@@ -9,6 +9,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
+import android.content.pm.PackageInfo;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 import android.view.LayoutInflater;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
@@ -81,7 +81,10 @@ public class LoadApkFragment extends Fragment implements AbsListView.OnItemClick
         for (File aFile : file) {
             Log.d(TAG, aFile.getAbsolutePath());
             File apkFile = new File(aFile.getAbsolutePath());
-            savedApis.add(new SavedApi(apkFile, apkFile.getName(), apkFile.lastModified(), apkFile.getAbsolutePath()));
+            PackageInfo info = getActivity().getPackageManager().getPackageArchiveInfo(apkFile.getAbsolutePath(),0);
+            if(info!=null&&info.packageName!=null&&info.packageName.startsWith("org.buildmlearn.")) {
+                savedApis.add(new SavedApi(apkFile, apkFile.getName(), apkFile.lastModified(), apkFile.getAbsolutePath()));
+            }
         }
 
         Collections.sort(savedApis, new Comparator<SavedApi>() {
@@ -184,7 +187,10 @@ public class LoadApkFragment extends Fragment implements AbsListView.OnItemClick
             for (File aFile : file) {
                 if (aFile.getName().contains(".apk")) {
                     File apkFile = new File(aFile.getAbsolutePath());
-                    savedApis.add(new SavedApi(apkFile, apkFile.getName(), apkFile.lastModified(), apkFile.getAbsolutePath()));
+                    PackageInfo info = getActivity().getPackageManager().getPackageArchiveInfo(apkFile.getAbsolutePath(),0);
+                    if(info!=null&&info.packageName!=null&&info.packageName.startsWith("org.buildmlearn.")) {
+                        savedApis.add(new SavedApi(apkFile, apkFile.getName(), apkFile.lastModified(), apkFile.getAbsolutePath()));
+                    }
                 }
             }
 


### PR DESCRIPTION
before in loadapkfragment all the apks present in downloads directory is displayed....now it displays only those genereated by buildmlearn