### PR TITLE
fixed app crash in phones with api level<19

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
@@ -877,4 +877,13 @@ public class TemplateEditor extends AppCompatActivity {
         templateMetaList.setAdapter(adapter);
     }
 
+    @Override
+    protected void onStop() {
+        super.onStop();
+        if(mApkGenerationDialog!=null) {
+            mApkGenerationDialog.dismiss();
+            mApkGenerationDialog=null;
+        }
+    }
+
 }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
@@ -53,7 +53,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.UnrecoverableKeyException;
 import java.util.Calendar;
-import java.util.Objects;
 
 import kellinwood.security.zipsigner.AutoKeyException;
 import kellinwood.security.zipsigner.ZipSigner;
@@ -345,7 +344,7 @@ public class SignerThread extends Thread {
                 name = null;
             }
 
-            if (!Objects.equals(name, oldName) || val != oldVal) {
+            if (!(name==oldName) || val != oldVal) {
                 changed = true;
                 if (!didLogNodeName) {
                     didLogNodeName = true;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/SignerThread.java
@@ -344,7 +344,7 @@ public class SignerThread extends Thread {
                 name = null;
             }
 
-            if (!(name==oldName) || val != oldVal) {
+            if ((!((name==null&&oldName==null)||(!(name==null&&oldName!=null))||(!(name!=null&&oldName==null)) || val != oldVal) {
                 changed = true;
                 if (!didLogNodeName) {
                     didLogNodeName = true;


### PR DESCRIPTION
there was a window leak error in phones using earlier versions of android and objects.equals required greater api level too.