### PR TITLE
Fixed Issue #175

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
@@ -1,6 +1,9 @@
 package org.buildmlearn.toolkit.fragment;
 
 import android.app.Activity;
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -9,8 +12,6 @@ import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.widget.Toast;
-
-import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.ToolkitApplication;
@@ -28,7 +29,6 @@ public class SettingsFragment extends PreferenceFragment {
 
     private static final int REQUEST_PICK_APK = 9985;
     private Preference prefUsername;
-
     public static float deleteDirectory(File file, float size) {
         if (file.exists()) {
             File[] listFiles = file.listFiles();
@@ -106,45 +106,53 @@ public class SettingsFragment extends PreferenceFragment {
                 if (resultCode == Activity.RESULT_OK) {
 
                     try {
-                        final MaterialDialog processDiaglog = new MaterialDialog.Builder(getActivity())
-                                .title(R.string.restore_progress_dialog)
-                                .content(R.string.restore_msg)
-                                .cancelable(false)
-                                .progress(true, 0)
-                                .show();
+                        final ProgressDialog processDialog = new ProgressDialog(getActivity());
+                                processDialog.setTitle(R.string.restore_progress_dialog);
+                                processDialog.setMessage("Restoring Project from Apk");
+                                processDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
+                                processDialog.setIndeterminate(true);
+                                processDialog.show();
 
 
                         InputStream inputStream = getActivity().getContentResolver().openInputStream(data.getData());
-                        RestoreThread restore = new RestoreThread(getActivity(), inputStream);
-
+                        RestoreThread restore = new RestoreThread(getActivity(), inputStream,processDialog);
                         restore.setRestoreListener(new RestoreThread.OnRestoreComplete() {
                             @Override
                             public void onSuccess(File assetFile) {
-                                processDiaglog.dismiss();
+                                processDialog.dismiss();
                                 Intent intentProject = new Intent(getActivity(), DeepLinkerActivity.class);
                                 intentProject.setData(Uri.fromFile(assetFile));
                                 getActivity().startActivity(intentProject);
                             }
-
                             @Override
                             public void onFail() {
-                                processDiaglog.dismiss();
-                                final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
-                                        .title(R.string.dialog_restore_title)
-                                        .content(R.string.dialog_restore_failed)
-                                        .positiveText(R.string.info_template_ok)
-                                        .build();
+                                processDialog.dismiss();
+                                final AlertDialog dialog = new AlertDialog.Builder(getActivity())
+                                        .setTitle(R.string.dialog_restore_title)
+                                        .setMessage(R.string.dialog_restore_failed)
+                                        .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
+                                            @Override
+                                            public void onClick(DialogInterface dialog, int which) {
+                                                dialog.dismiss();
+                                            }
+                                        })
+                                        .create();
                                 dialog.show();
                             }
 
                             @Override
                             public void onFail(Exception e) {
-                                processDiaglog.dismiss();
-                                final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
-                                        .title(R.string.dialog_restore_title)
-                                        .content(R.string.dialog_restore_failed)
-                                        .positiveText(R.string.info_template_ok)
-                                        .build();
+                                processDialog.dismiss();
+                                final AlertDialog dialog = new AlertDialog.Builder(getActivity())
+                                        .setTitle(R.string.dialog_restore_title)
+                                        .setMessage(R.string.dialog_restore_failed)
+                                        .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
+                                            @Override
+                                            public void onClick(DialogInterface dialog, int which) {
+                                                dialog.dismiss();
+                                            }
+                                        })
+                                        .create();
                                 dialog.show();
                             }
                         });
@@ -154,11 +162,16 @@ public class SettingsFragment extends PreferenceFragment {
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();
 
-                        final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
-                                .title(R.string.dialog_restore_title)
-                                .content(R.string.dialog_restore_fileerror)
-                                .positiveText(R.string.info_template_ok)
-                                .build();
+                        final AlertDialog dialog = new AlertDialog.Builder(getActivity())
+                                .setTitle(R.string.dialog_restore_title)
+                                .setMessage(R.string.dialog_restore_fileerror)
+                                .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        dialog.dismiss();
+                                    }
+                                })
+                                .create();
                         dialog.show();
                     }
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
@@ -1,9 +1,6 @@
 package org.buildmlearn.toolkit.fragment;
 
 import android.app.Activity;
-import android.app.AlertDialog;
-import android.app.ProgressDialog;
-import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
@@ -12,6 +9,8 @@ import android.preference.Preference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.widget.Toast;
+
+import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.ToolkitApplication;
@@ -29,6 +28,7 @@ public class SettingsFragment extends PreferenceFragment {
 
     private static final int REQUEST_PICK_APK = 9985;
     private Preference prefUsername;
+
     public static float deleteDirectory(File file, float size) {
         if (file.exists()) {
             File[] listFiles = file.listFiles();
@@ -106,53 +106,45 @@ public class SettingsFragment extends PreferenceFragment {
                 if (resultCode == Activity.RESULT_OK) {
 
                     try {
-                        final ProgressDialog processDialog = new ProgressDialog(getActivity());
-                                processDialog.setTitle(R.string.restore_progress_dialog);
-                                processDialog.setMessage("Restoring Project from Apk");
-                                processDialog.setProgressStyle(ProgressDialog.STYLE_SPINNER);
-                                processDialog.setIndeterminate(true);
-                                processDialog.show();
+                        final MaterialDialog processDiaglog = new MaterialDialog.Builder(getActivity())
+                                .title(R.string.restore_progress_dialog)
+                                .content(R.string.restore_msg)
+                                .cancelable(false)
+                                .progress(true, 0)
+                                .show();
 
 
                         InputStream inputStream = getActivity().getContentResolver().openInputStream(data.getData());
-                        RestoreThread restore = new RestoreThread(getActivity(), inputStream,processDialog);
+                        RestoreThread restore = new RestoreThread(getActivity(), inputStream,processDiaglog);
+
                         restore.setRestoreListener(new RestoreThread.OnRestoreComplete() {
                             @Override
                             public void onSuccess(File assetFile) {
-                                processDialog.dismiss();
+                                processDiaglog.dismiss();
                                 Intent intentProject = new Intent(getActivity(), DeepLinkerActivity.class);
                                 intentProject.setData(Uri.fromFile(assetFile));
                                 getActivity().startActivity(intentProject);
                             }
+
                             @Override
                             public void onFail() {
-                                processDialog.dismiss();
-                                final AlertDialog dialog = new AlertDialog.Builder(getActivity())
-                                        .setTitle(R.string.dialog_restore_title)
-                                        .setMessage(R.string.dialog_restore_failed)
-                                        .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(DialogInterface dialog, int which) {
-                                                dialog.dismiss();
-                                            }
-                                        })
-                                        .create();
+                                processDiaglog.dismiss();
+                                final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+                                        .title(R.string.dialog_restore_title)
+                                        .content(R.string.dialog_restore_failed)
+                                        .positiveText(R.string.info_template_ok)
+                                        .build();
                                 dialog.show();
                             }
 
                             @Override
                             public void onFail(Exception e) {
-                                processDialog.dismiss();
-                                final AlertDialog dialog = new AlertDialog.Builder(getActivity())
-                                        .setTitle(R.string.dialog_restore_title)
-                                        .setMessage(R.string.dialog_restore_failed)
-                                        .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
-                                            @Override
-                                            public void onClick(DialogInterface dialog, int which) {
-                                                dialog.dismiss();
-                                            }
-                                        })
-                                        .create();
+                                processDiaglog.dismiss();
+                                final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+                                        .title(R.string.dialog_restore_title)
+                                        .content(R.string.dialog_restore_failed)
+                                        .positiveText(R.string.info_template_ok)
+                                        .build();
                                 dialog.show();
                             }
                         });
@@ -162,16 +154,11 @@ public class SettingsFragment extends PreferenceFragment {
                     } catch (FileNotFoundException e) {
                         e.printStackTrace();
 
-                        final AlertDialog dialog = new AlertDialog.Builder(getActivity())
-                                .setTitle(R.string.dialog_restore_title)
-                                .setMessage(R.string.dialog_restore_fileerror)
-                                .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
-                                    @Override
-                                    public void onClick(DialogInterface dialog, int which) {
-                                        dialog.dismiss();
-                                    }
-                                })
-                                .create();
+                        final MaterialDialog dialog = new MaterialDialog.Builder(getActivity())
+                                .title(R.string.dialog_restore_title)
+                                .content(R.string.dialog_restore_fileerror)
+                                .positiveText(R.string.info_template_ok)
+                                .build();
                         dialog.show();
                     }
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
@@ -6,11 +6,12 @@ package org.buildmlearn.toolkit.utilities;
 
 
 import android.app.AlertDialog;
-import android.app.ProgressDialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.os.Handler;
 import android.os.Looper;
+
+import com.afollestad.materialdialogs.MaterialDialog;
 
 import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.ToolkitApplication;
@@ -27,10 +28,10 @@ public class RestoreThread extends Thread {
     private static final String TEMP_FOLDER = "rtf";
     private final Context context;
     private final InputStream zipInputStream;
-    private final ProgressDialog processDialog;
+    private final MaterialDialog processDialog;
     private OnRestoreComplete listener;
 
-    public RestoreThread(Context context, InputStream zipInputStream, ProgressDialog processDialog) {
+    public RestoreThread(Context context, InputStream zipInputStream, MaterialDialog processDialog) {
         this.context = context;
         this.zipInputStream = zipInputStream;
         this.processDialog = processDialog;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/utilities/RestoreThread.java
@@ -5,8 +5,14 @@ package org.buildmlearn.toolkit.utilities;
  */
 
 
+import android.app.AlertDialog;
+import android.app.ProgressDialog;
 import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Handler;
+import android.os.Looper;
 
+import org.buildmlearn.toolkit.R;
 import org.buildmlearn.toolkit.ToolkitApplication;
 import org.buildmlearn.toolkit.model.Template;
 
@@ -21,12 +27,13 @@ public class RestoreThread extends Thread {
     private static final String TEMP_FOLDER = "rtf";
     private final Context context;
     private final InputStream zipInputStream;
-
+    private final ProgressDialog processDialog;
     private OnRestoreComplete listener;
 
-    public RestoreThread(Context context, InputStream zipInputStream) {
+    public RestoreThread(Context context, InputStream zipInputStream, ProgressDialog processDialog) {
         this.context = context;
         this.zipInputStream = zipInputStream;
+        this.processDialog = processDialog;
     }
 
     public void setRestoreListener(OnRestoreComplete listener) {
@@ -66,8 +73,26 @@ public class RestoreThread extends Thread {
             }
 
             if (data == null) {
-                if (listener != null)
-                    listener.onFail();
+                if (listener != null){
+                    Handler mHandler=new Handler(Looper.getMainLooper());
+                    mHandler.post(new Runnable() {
+                        @Override
+                        public void run() {
+                            processDialog.dismiss();
+                            final AlertDialog dialog = new AlertDialog.Builder(context)
+                                    .setTitle(R.string.dialog_restore_title)
+                                    .setMessage(R.string.dialog_restore_fileerror)
+                                    .setPositiveButton(R.string.info_template_ok, new DialogInterface.OnClickListener() {
+                                        @Override
+                                        public void onClick(DialogInterface dialog, int which) {
+                                            dialog.dismiss();
+                                        }
+                                    })
+                                    .create();
+                            dialog.show();
+                        }
+                    });
+                }
                 return;
             }
 


### PR DESCRIPTION
Fixes: #175 
https://youtu.be/KtQursz2k9g
The issue has been resolved. Here's the link depicting the same. Earlier the app used to crash when We tried to open any other apk or any file like PDFs, .mp4 etc. But now the app doesn't crashes and it displays a message that "This file can't be opened.".

THINGS DONE:-
1) Created a handler inside the RestoreThread Class to display the error Dialog Box.
2) Fixed a typo processDiaglog -> processDialog.
3) Replaced Affolestad's Dialog boxes with support library alert boxes.

Thanks.
