### PR TITLE
Multiselection bug solved

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/SavedApiAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/SavedApiAdapter.java
@@ -79,7 +79,7 @@ public class SavedApiAdapter extends BaseAdapter {
         {
             positions.add((Integer)key);
         }
-        Collections.sort(positions);
+        Collections.sort(positions,Collections.reverseOrder());
         return positions;
     }
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/SavedProjectAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/SavedProjectAdapter.java
@@ -74,7 +74,7 @@ public class SavedProjectAdapter extends BaseAdapter {
         {
             positions.add((Integer)key);
         }
-        Collections.sort(positions);
+        Collections.sort(positions, Collections.reverseOrder());
         return positions;
     }
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadApkFragment.java
@@ -343,8 +343,6 @@ public class LoadApkFragment extends Fragment implements AbsListView.OnItemClick
                 Intent sendIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
                 sendIntent.setType("application/zip");
                 for(int selectedPosition : selectedPositions) {
-                    if(selectedPosition != selectedPositions.get(0))
-                        selectedPosition--;
                     SavedApi apk = savedApis.get(selectedPosition);
                     File file = new File(apk.getFile().getPath());
                     Uri fileUri = Uri.fromFile(file);
@@ -440,13 +438,12 @@ public class LoadApkFragment extends Fragment implements AbsListView.OnItemClick
         ArrayList<Integer> selectedPositions = mAdapter.getSelectedPositions();
         boolean deleted = false;
         for(int selectedPosition : selectedPositions) {
-            if (selectedPosition != selectedPositions.get(0))
-                selectedPosition--;
             SavedApi apk = savedApis.get(selectedPosition);
             File file = new File(apk.getFile().getPath());
             deleted = file.delete();
             if (deleted) {
                 savedApis.remove(selectedPosition);
+                mAdapter.removeSelectedPosition(selectedPosition);
                 mAdapter.notifyDataSetChanged();
                 setEmptyText();
             }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadProjectFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/LoadProjectFragment.java
@@ -372,8 +372,6 @@ public class LoadProjectFragment extends Fragment implements AbsListView.OnItemC
                 Intent sendIntent = new Intent(Intent.ACTION_SEND_MULTIPLE);
                 sendIntent.setType("application/zip");
                 for(int selectedPosition : selectedPositions) {
-                    if(selectedPosition != selectedPositions.get(0))
-                        selectedPosition--;
                     SavedProject project = savedProjects.get(selectedPosition);
                     File file = new File(project.getFile().getPath());
 
@@ -471,11 +469,10 @@ public class LoadProjectFragment extends Fragment implements AbsListView.OnItemC
         ArrayList<Integer> selectedPositions = mAdapter.getSelectedPositions();
         boolean deleted = false;
         for(int selectedPosition : selectedPositions) {
-            if(selectedPosition!=selectedPositions.get(0))
-                selectedPosition--;
             SavedProject project = savedProjects.get(selectedPosition);
             File file = new File(project.getFile().getPath());
             deleted = file.delete();
+
             if (deleted) {
                 savedProjects.remove(selectedPosition);
                 mAdapter.removeSelectedPosition(selectedPosition);


### PR DESCRIPTION
#142 #162 #163 #164

Hey @opticod , please review the PR. 

Overview - The bug was because -Earlier, the code below was to update SelectedPosition  because everytime element is deleted from arraylist, indices of elements changes. But this will fail if user make deletion operation more than once.    

```
if(selectedPosition!=selectedPositions.get(0))
                selectedPosition--;
```

To solve this bug, I have sorted the arraylist in reverse order which solves the  problem in efficient way and is standard way of handling such cases (Removing multiple elements from arraylist). 
Also , in SaveApkFragment the deleted elements were not removed from the selectedPositions Map after the deletion operation.Thanks.
