### PR TITLE
App Crashes if Meta Data is missing in Match Template 

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
@@ -669,6 +669,10 @@ public class TemplateEditor extends AppCompatActivity {
                     Toast.makeText(this, "Unable to perform action: No Data", Toast.LENGTH_SHORT).show();
                     return null;
                 }
+                if (selectedTemplate.getItems(doc).get(0).getTagName().equals("item") && (templateId == 5 || templateId == 7)) {
+                    Toast.makeText(this, "Unable to perform action: Add Meta Details", Toast.LENGTH_SHORT).show();
+                    return null;
+                }
                 for (Element item : selectedTemplate.getItems(doc)) {
                     dataElement.appendChild(item);
                 }


### PR DESCRIPTION
@opticod  I have solved the issue as in #254. Please check.