### PR TITLE
App crash on closing simulator before finishing timer

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/MainFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/MainFragment.java
@@ -117,9 +117,10 @@ public class MainFragment extends Fragment implements NavigationView.OnNavigatio
 
                 Fragment frag = QuestionFragment.newInstance();
                 frag.setArguments(arguments);
-                getActivity().getSupportFragmentManager().popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
-
-                getActivity().getSupportFragmentManager().beginTransaction().replace(((ViewGroup) getView().getParent()).getId(), frag).addToBackStack(null).commit();
+                if(getActivity()!=null) {
+                    getActivity().getSupportFragmentManager().popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
+                    getActivity().getSupportFragmentManager().beginTransaction().replace(((ViewGroup) getView().getParent()).getId(), frag).addToBackStack(null).commit();
+                }
             }
         }.start();
 


### PR DESCRIPTION
#290
This was happening because timer doesn't stops on closing simulator and when it stops , it can't find the simulator activity (get null reference).