### PR TITLE
Fix warning in AndroidManifest.xml

### DIFF
--- a/source-code/app/src/main/AndroidManifest.xml
+++ b/source-code/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
             android:name=".activity.HomeActivity"
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"
-            android:theme="@style/NoActionBarThemeTransparentStatusBar"></activity>
+            android:theme="@style/NoActionBarThemeTransparentStatusBar" />
         <activity
             android:name=".simulator.Simulator"
             android:label="@string/title_activity_simulator"
@@ -41,7 +41,7 @@
             android:name=".activity.TemplateEditor"
             android:configChanges="orientation|screenSize"
             android:label="@string/title_activity_template_editor"
-            android:theme="@style/AppTheme.NoActionBar"></activity>
+            android:theme="@style/AppTheme.NoActionBar" />
         <activity
             android:name=".activity.FirstRunActivity"
             android:label="@string/app_name"
@@ -56,7 +56,7 @@
         <activity
             android:name=".activity.TutorialActivity"
             android:label="@string/title_activity_tutorial"
-            android:theme="@style/Buildmlearn.FullScreen"></activity>
+            android:theme="@style/Buildmlearn.FullScreen" />
         <activity
             android:name=".activity.AboutBuildmLearn"
             android:label="@string/title_activity_about_buildm_learn"


### PR DESCRIPTION
Fix `XML has empty body` warning in `AndroidManifest.xml`  by getting rid of closing tags and replacing them with the self closing tags.