### PR TITLE
Changed variable names to lowerCamelCase. Fixes #328

### DIFF
--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/FirstRunActivity.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/FirstRunActivity.java
@@ -46,9 +46,9 @@ public class FirstRunActivity extends AppCompatActivity {
 
 
         findViewById(R.id.focus_thief).clearFocus();
-        Animation anim_bounceinup=AnimationUtils.loadAnimation(getBaseContext(),R.anim.bounceinup);
+        Animation animBounceinup=AnimationUtils.loadAnimation(getBaseContext(),R.anim.bounceinup);
         name = (EditText) findViewById(R.id.first_name);
-        name.startAnimation(anim_bounceinup);
+        name.startAnimation(animBounceinup);
         name.setOnKeyListener(new View.OnKeyListener() {
             @Override
             public boolean onKey(View v, int keyCode, KeyEvent event) {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TemplateEditor.java
@@ -100,10 +100,10 @@ public class TemplateEditor extends AppCompatActivity {
     public void openBottomSheet (View v) {
 
         View view = getLayoutInflater ().inflate (R.layout.bottom_sheet_view, null);
-        TextView txt_save_apk = (TextView)view.findViewById( R.id.txt_save_apk);
-        TextView txt_save_project = (TextView)view.findViewById( R.id.txt_save_project);
-        TextView txt_share_apk = (TextView)view.findViewById( R.id.txt_share_apk);
-        final TextView txt_shareProject = (TextView)view.findViewById( R.id.txt_share_project);
+        TextView txtSaveApk = (TextView)view.findViewById( R.id.txt_save_apk);
+        TextView txtSaveProject = (TextView)view.findViewById( R.id.txt_save_project);
+        TextView txtShareApk = (TextView)view.findViewById( R.id.txt_share_apk);
+        final TextView txtShareProject = (TextView)view.findViewById( R.id.txt_share_project);
 
         final Dialog mBottomSheetDialog = new Dialog (TemplateEditor.this,
                 R.style.MaterialDialogSheet);
@@ -116,7 +116,7 @@ public class TemplateEditor extends AppCompatActivity {
 
 
         //save project
-        txt_save_project.setOnClickListener(new View.OnClickListener() {
+        txtSaveProject.setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
@@ -126,7 +126,7 @@ public class TemplateEditor extends AppCompatActivity {
         });
 
         //share project
-        txt_shareProject.setOnClickListener(new View.OnClickListener() {
+        txtShareProject.setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
@@ -135,26 +135,26 @@ public class TemplateEditor extends AppCompatActivity {
             }
         });
 
-        txt_share_apk.setOnClickListener(new View.OnClickListener() {
+        txtShareApk.setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
-                share_apk();
+                shareApk();
                 mBottomSheetDialog.dismiss();
             }
         });
 
-        txt_save_apk.setOnClickListener(new View.OnClickListener() {
+        txtSaveApk.setOnClickListener(new View.OnClickListener() {
 
             @Override
             public void onClick(View v) {
-                save_apk();
+                saveApk();
                 mBottomSheetDialog.dismiss();
             }
         });
     }
 
-    private void save_apk() {
+    private void saveApk() {
         String savedFilePath;
         savedFilePath = saveProject();
         if (savedFilePath == null || savedFilePath.length() == 0) {
@@ -214,7 +214,7 @@ public class TemplateEditor extends AppCompatActivity {
         signer.start();
     }
 
-    private void share_apk() {
+    private void shareApk() {
         String savedFilePath;
         savedFilePath = saveProject();
         if (savedFilePath == null || savedFilePath.length() == 0) {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TutorialActivity.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/activity/TutorialActivity.java
@@ -43,9 +43,9 @@ public class TutorialActivity extends AppCompatActivity {
         mPager.addOnPageChangeListener(viewPagerPageChangeListener);
     }
 
-    private void addBottomDots(int current_slide) {
+    private void addBottomDots(int currentSlide) {
         TextView[] dots = new TextView[Tutorial.values().length];
-        int dot_colorActive = getResources().getColor(R.color.selected_dot);
+        int dotColorActive = getResources().getColor(R.color.selected_dot);
 
         indicatingDotsContainer.removeAllViews();
 
@@ -59,9 +59,9 @@ public class TutorialActivity extends AppCompatActivity {
 
         //dot corresponding to current slide is given active color i.e white color
         if (dots.length > 0) {
-            dots[current_slide].setTextColor(dot_colorActive);
-            dots[current_slide].setText(Html.fromHtml("&#8226;"));
-            dots[current_slide].setTextSize(TypedValue.COMPLEX_UNIT_SP,32);
+            dots[currentSlide].setTextColor(dotColorActive);
+            dots[currentSlide].setText(Html.fromHtml("&#8226;"));
+            dots[currentSlide].setTextSize(TypedValue.COMPLEX_UNIT_SP,32);
         }
     }
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/TutorialAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/adapter/TutorialAdapter.java
@@ -77,9 +77,11 @@ public class TutorialAdapter extends PagerAdapter {
                 }
             });
         } else {
+
             convertView = View.inflate(mActivity,R.layout.tutorial_layout, null);
-            View skip_button = convertView.findViewById(R.id.skip_button);
-            skip_button.setVisibility(View.GONE);
+            View skipButton = convertView.findViewById(R.id.skip_button);
+            skipButton.setVisibility(View.GONE);
+
             ImageView deviceImage = (ImageView) convertView
                     .findViewById(R.id.device_image);
             TextView title = (TextView) convertView
@@ -95,7 +97,7 @@ public class TutorialAdapter extends PagerAdapter {
             title.setText(tutorial.getTitle());
             description.setText(tutorial.getDescription());
             if(!SkipTutorial) {
-                skip_button.setVisibility(View.VISIBLE);
+                skipButton.setVisibility(View.VISIBLE);
             }
             convertView.findViewById(R.id.skip_button).setOnClickListener(new View.OnClickListener() {
                 @Override

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/data/ComprehensionDb.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/data/ComprehensionDb.java
@@ -94,11 +94,11 @@ public class ComprehensionDb {
             Cursor cursor = getQuestionCursorById(i);
             cursor.moveToFirst();
 
-            String correct_answer = cursor.getString(Constants.COL_CORRECT_ANSWER);
+            String correctAnswer = cursor.getString(Constants.COL_CORRECT_ANSWER);
             int attempted = cursor.getInt(Constants.COL_ATTEMPTED);
             if (attempted == 1) {
                 String answer = cursor.getString(Constants.COL_ANSWERED);
-                if (answer.equals(correct_answer)) {
+                if (answer.equals(correctAnswer)) {
                     stat[0]++;
                 } else {
                     stat[1]++;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/QuestionFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/QuestionFragment.java
@@ -99,10 +99,10 @@ public class QuestionFragment extends Fragment
         Cursor cursor = db.getQuestionCursorById(Integer.parseInt(questionId));
         cursor.moveToFirst();
         String question = cursor.getString(Constants.COL_QUESTION);
-        String option_1 = cursor.getString(Constants.COL_OPTION_1);
-        String option_2 = cursor.getString(Constants.COL_OPTION_2);
-        String option_3 = cursor.getString(Constants.COL_OPTION_3);
-        String option_4 = cursor.getString(Constants.COL_OPTION_4);
+        String optionOne = cursor.getString(Constants.COL_OPTION_1);
+        String optionTwo = cursor.getString(Constants.COL_OPTION_2);
+        String optionThree = cursor.getString(Constants.COL_OPTION_3);
+        String optionFour = cursor.getString(Constants.COL_OPTION_4);
         int attempted = cursor.getInt(Constants.COL_ATTEMPTED);
         String answered;
 
@@ -154,21 +154,21 @@ public class QuestionFragment extends Fragment
 
         ((TextView) rootView.findViewById(R.id.question_title)).setText(String.format(Locale.getDefault(), "Question No : %1$s", questionId));
         ((TextView) rootView.findViewById(R.id.question)).setText(question);
-        if (option_1 != null) {
+        if (optionOne != null) {
             rootView.findViewById(R.id.radioButton1).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton1)).setText(option_1);
+            ((TextView) rootView.findViewById(R.id.radioButton1)).setText(optionOne);
         }
-        if (option_2 != null) {
+        if (optionTwo != null) {
             rootView.findViewById(R.id.radioButton2).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton2)).setText(option_2);
+            ((TextView) rootView.findViewById(R.id.radioButton2)).setText(optionTwo);
         }
-        if (option_3 != null) {
+        if (optionThree != null) {
             rootView.findViewById(R.id.radioButton3).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton3)).setText(option_3);
+            ((TextView) rootView.findViewById(R.id.radioButton3)).setText(optionThree);
         }
-        if (option_4 != null) {
+        if (optionFour != null) {
             rootView.findViewById(R.id.radioButton4).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton4)).setText(option_4);
+            ((TextView) rootView.findViewById(R.id.radioButton4)).setText(optionFour);
         }
 
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/comprehensiontemplate/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.comprehension_title));
 
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/DetailActivityFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/DetailActivityFragment.java
@@ -46,7 +46,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
     private static final int DETAIL_LOADER = 0;
 
     private View rootView;
-    private String dict_Id;
+    private String dictId;
     private DictDb db;
     private TextToSpeech tts;
     private ProgressDialog progress;
@@ -64,7 +64,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                              Bundle savedInstanceState) {
         Bundle arguments = getArguments();
         if (arguments != null) {
-            dict_Id = arguments.getString(Intent.EXTRA_TEXT);
+            dictId = arguments.getString(Intent.EXTRA_TEXT);
         }
         rootView = inflater.inflate(R.layout.fragment_detail_dict, container, false);
 
@@ -121,14 +121,14 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        if (null != dict_Id) {
+        if (null != dictId) {
             switch (id) {
                 case DETAIL_LOADER:
 
                     return new CursorLoader(getActivity(), null, Constants.DICT_COLUMNS, null, null, null) {
                         @Override
                         public Cursor loadInBackground() {
-                            return db.getDictCursorById(Integer.parseInt(dict_Id));
+                            return db.getDictCursorById(Integer.parseInt(dictId));
                         }
                     };
                 default: //do nothing
@@ -171,11 +171,11 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                 rootView.findViewById(R.id.submit).setOnClickListener(new View.OnClickListener() {
                     @Override
                     public void onClick(View v) {
-                        String passage_usr = passageText.getText().toString();
+                        String passageUsr = passageText.getText().toString();
 
                         Bundle arguments = new Bundle();
-                        arguments.putString(Intent.EXTRA_TEXT, String.valueOf(dict_Id));
-                        arguments.putString(Constants.passage, passage_usr);
+                        arguments.putString(Intent.EXTRA_TEXT, String.valueOf(dictId));
+                        arguments.putString(Constants.passage, passageUsr);
 
                         Fragment frag = ResultActivityFragment.newInstance();
                         frag.setArguments(arguments);

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/ResultActivityFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/ResultActivityFragment.java
@@ -42,7 +42,7 @@ public class ResultActivityFragment extends Fragment implements LoaderCallbacks<
     private final ContentValues dictValues;
 
     private View rootView;
-    private String dict_Id;
+    private String dictId;
     private String passageEntered;
     private DictDb db;
 
@@ -60,7 +60,7 @@ public class ResultActivityFragment extends Fragment implements LoaderCallbacks<
                              Bundle savedInstanceState) {
         Bundle arguments = getArguments();
         if (arguments != null) {
-            dict_Id = arguments.getString(Intent.EXTRA_TEXT);
+            dictId = arguments.getString(Intent.EXTRA_TEXT);
             passageEntered = arguments.getString(Constants.passage);
         }
         rootView = inflater.inflate(R.layout.fragment_result_dict, container, false);
@@ -116,14 +116,14 @@ public class ResultActivityFragment extends Fragment implements LoaderCallbacks<
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        if (null != dict_Id) {
+        if (null != dictId) {
             switch (id) {
                 case DETAIL_LOADER:
 
                     return new CursorLoader(getActivity(), null, Constants.DICT_COLUMNS, null, null, null) {
                         @Override
                         public Cursor loadInBackground() {
-                            return db.getDictCursorById(Integer.parseInt(dict_Id));
+                            return db.getDictCursorById(Integer.parseInt(dictId));
                         }
                     };
                 default: //do nothing
@@ -160,7 +160,7 @@ public class ResultActivityFragment extends Fragment implements LoaderCallbacks<
                         getActivity().getSupportFragmentManager().popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
 
                         Bundle arguments = new Bundle();
-                        arguments.putString(Intent.EXTRA_TEXT, dict_Id);
+                        arguments.putString(Intent.EXTRA_TEXT, dictId);
 
                         Fragment frag = org.buildmlearn.toolkit.dictationtemplate.fragment.DetailActivityFragment.newInstance();
                         frag.setArguments(arguments);

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/dictationtemplate/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.dictation_title));
 
         rootView.findViewById(R.id.enter).setOnClickListener(new View.OnClickListener() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/flashcardtemplate/fragment/MainFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/flashcardtemplate/fragment/MainFragment.java
@@ -144,12 +144,12 @@ public class MainFragment extends Fragment implements NavigationView.OnNavigatio
         mi.setTitle(mi.getTitle());
 
 
-        Cursor flash_cursor = db.getFlashCursorById(Integer.parseInt(FlashId));
-        flash_cursor.moveToFirst();
-        String question = flash_cursor.getString(Constants.COL_QUESTION);
-        String answer = flash_cursor.getString(Constants.COL_ANSWER);
-        String hint = flash_cursor.getString(Constants.COL_HINT);
-        String base64 = flash_cursor.getString(Constants.COL_BASE64);
+        Cursor flashCursor = db.getFlashCursorById(Integer.parseInt(FlashId));
+        flashCursor.moveToFirst();
+        String question = flashCursor.getString(Constants.COL_QUESTION);
+        String answer = flashCursor.getString(Constants.COL_ANSWER);
+        String hint = flashCursor.getString(Constants.COL_HINT);
+        String base64 = flashCursor.getString(Constants.COL_BASE64);
 
         assert rootView.findViewById(R.id.intro_number) != null;
         ((TextView) rootView.findViewById(R.id.intro_number)).setText(String.format(Locale.ENGLISH, "Card #%d of %d", Integer.parseInt(FlashId), numFlash));

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/flashcardtemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/flashcardtemplate/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.main_title_flash));
 
         rootView.findViewById(R.id.enter).setOnClickListener(new View.OnClickListener() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/fragment/SettingsFragment.java
@@ -74,8 +74,8 @@ public class SettingsFragment extends PreferenceFragment {
             }
         });
 
-        Preference rate_preference=findPreference(getString(R.string.pref_rate_key));
-        rate_preference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+        Preference ratePreference=findPreference(getString(R.string.pref_rate_key));
+        ratePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
                 if(NetworkUtils.isNetworkAvailable(getActivity()))

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/infotemplate/fragment/DetailActivityFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/infotemplate/fragment/DetailActivityFragment.java
@@ -37,7 +37,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
     private final ContentValues infoValues;
 
     private View rootView;
-    private String info_Id;
+    private String infoId;
     private InfoDb db;
 
     public DetailActivityFragment() {
@@ -54,7 +54,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                              Bundle savedInstanceState) {
         Bundle arguments = getArguments();
         if (arguments != null) {
-            info_Id = arguments.getString(Intent.EXTRA_TEXT);
+            infoId = arguments.getString(Intent.EXTRA_TEXT);
         }
         rootView = inflater.inflate(R.layout.fragment_detail_info, container, false);
 
@@ -108,14 +108,14 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        if (null != info_Id) {
+        if (null != infoId) {
             switch (id) {
                 case DETAIL_LOADER:
 
                     return new CursorLoader(getActivity(), null, Constants.INFO_COLUMNS, null, null, null) {
                         @Override
                         public Cursor loadInBackground() {
-                            return db.getInfoCursorById(Integer.parseInt(info_Id));
+                            return db.getInfoCursorById(Integer.parseInt(infoId));
                         }
                     };
                 default: //do nothing
@@ -144,7 +144,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
                 final long numColumns = db.getCount();
 
-                if (Integer.parseInt(info_Id) == numColumns) {
+                if (Integer.parseInt(infoId) == numColumns) {
 
                     rootView.findViewById(R.id.next).setVisibility(View.INVISIBLE);
                     rootView.findViewById(R.id.exit).setOnClickListener(new View.OnClickListener() {
@@ -161,7 +161,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                         @Override
                         public void onClick(View v) {
 
-                            long nextInfoId = Integer.parseInt(info_Id) + 1;
+                            long nextInfoId = Integer.parseInt(infoId) + 1;
 
                             Bundle arguments = new Bundle();
                             arguments.putString(Intent.EXTRA_TEXT, String.valueOf(nextInfoId));
@@ -174,7 +174,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                     });
                 }
 
-                if (Integer.parseInt(info_Id) == 1) {
+                if (Integer.parseInt(infoId) == 1) {
 
                     rootView.findViewById(R.id.previous).setVisibility(View.INVISIBLE);
 
@@ -184,7 +184,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                         @Override
                         public void onClick(View v) {
 
-                            int prevInfoId = Integer.parseInt(info_Id) - 1;
+                            int prevInfoId = Integer.parseInt(infoId) - 1;
 
                             if (prevInfoId >= 1) {
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/infotemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/infotemplate/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.main_title_info));
 
         rootView.findViewById(R.id.enter).setOnClickListener(new View.OnClickListener() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/data/SpellDb.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/data/SpellDb.java
@@ -74,11 +74,11 @@ public class SpellDb {
             Cursor cursor = getSpellingCursorById(i);
             cursor.moveToFirst();
 
-            String correct_answer = cursor.getString(Constants.COL_WORD);
+            String correctAnswer = cursor.getString(Constants.COL_WORD);
             int attempted = cursor.getInt(Constants.COL_ATTEMPTED);
             if (attempted == 1) {
                 String answer = cursor.getString(Constants.COL_ANSWERED);
-                if (answer.equalsIgnoreCase(correct_answer)) {
+                if (answer.equalsIgnoreCase(correctAnswer)) {
                     stat[0]++;
                 } else {
                     stat[1]++;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/MainFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/MainFragment.java
@@ -51,9 +51,9 @@ public class MainFragment extends Fragment
     private static final float MIN_SPEECH_RATE = 0.01f;
     private android.app.AlertDialog mAlert;
     private Context mContext;
-    private Button mBtn_Spell, mBtn_Skip;
-    private EditText mEt_Spelling;
-    private SeekBar mSb_SpeechRate;
+    private Button mBtnSpell, mBtnSkip;
+    private EditText mEtSpelling;
+    private SeekBar mSbSpeechRate;
     private SpellDb db;
     private TextToSpeech tts;
     private ProgressDialog progress;
@@ -149,19 +149,19 @@ public class MainFragment extends Fragment
         mi.setTitle(mi.getTitle());
 
 
-        mBtn_Spell = (Button) rootView.findViewById(R.id.spell_it);
-        mBtn_Skip = (Button) rootView.findViewById(R.id.skip);
-        mSb_SpeechRate = (SeekBar) rootView.findViewById(R.id.seek_bar);
-        TextView mTv_WordNumber = (TextView) rootView.findViewById(R.id.intro_number);
+        mBtnSpell = (Button) rootView.findViewById(R.id.spell_it);
+        mBtnSkip = (Button) rootView.findViewById(R.id.skip);
+        mSbSpeechRate = (SeekBar) rootView.findViewById(R.id.seek_bar);
+        TextView mTvWordNumber = (TextView) rootView.findViewById(R.id.intro_number);
 
-        mBtn_Spell.setEnabled(false);
-        mBtn_Skip.setEnabled(false);
-        mTv_WordNumber.setText(String.format(Locale.ENGLISH, "Word #%d of %d", Integer.parseInt(spellId), numQues));
+        mBtnSpell.setEnabled(false);
+        mBtnSkip.setEnabled(false);
+        mTvWordNumber.setText(String.format(Locale.ENGLISH, "Word #%d of %d", Integer.parseInt(spellId), numQues));
 
-        Cursor spell_cursor = db.getSpellingCursorById(Integer.parseInt(spellId));
-        spell_cursor.moveToFirst();
-        String word = spell_cursor.getString(Constants.COL_WORD);
-        String answered = spell_cursor.getString(Constants.COL_ANSWERED);
+        Cursor spellCursor = db.getSpellingCursorById(Integer.parseInt(spellId));
+        spellCursor.moveToFirst();
+        String word = spellCursor.getString(Constants.COL_WORD);
+        String answered = spellCursor.getString(Constants.COL_ANSWERED);
 
         setListeners(spellId, word, answered);
 
@@ -214,7 +214,7 @@ public class MainFragment extends Fragment
                 progress.show();
 
 
-                float speechRate = getProgressValue(mSb_SpeechRate.getProgress());
+                float speechRate = getProgressValue(mSbSpeechRate.getProgress());
                 tts.setSpeechRate(speechRate);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -225,10 +225,10 @@ public class MainFragment extends Fragment
                     map.put(TextToSpeech.Engine.KEY_PARAM_UTTERANCE_ID, "dict");
                     tts.speak(word, TextToSpeech.QUEUE_FLUSH, map);
                 }
-                mBtn_Spell.setEnabled(true);
-                mBtn_Skip.setEnabled(true);
-                mBtn_Skip.setTextColor(ContextCompat.getColor(mContext, R.color.colorAccent_spell));
-                mBtn_Spell.setTextColor(ContextCompat.getColor(mContext, R.color.colorAccent_spell));
+                mBtnSpell.setEnabled(true);
+                mBtnSkip.setEnabled(true);
+                mBtnSkip.setTextColor(ContextCompat.getColor(mContext, R.color.colorAccent_spell));
+                mBtnSpell.setTextColor(ContextCompat.getColor(mContext, R.color.colorAccent_spell));
             }
         });
 
@@ -246,8 +246,8 @@ public class MainFragment extends Fragment
                 if (mAlert != null && !mAlert.isShowing()) {
                     mAlert.show();
                 }
-                mEt_Spelling = (EditText) mAlert.findViewById(R.id.et_spelling);
-                mEt_Spelling.setText(answered);
+                mEtSpelling = (EditText) mAlert.findViewById(R.id.et_spelling);
+                mEtSpelling.setText(answered);
 
                 Button mBtn_Submit = (Button) mAlert.findViewById(R.id.btn_submit);
                 mBtn_Submit.setOnClickListener(new View.OnClickListener() {
@@ -263,7 +263,7 @@ public class MainFragment extends Fragment
     }
 
     private void submit(String spell) {
-        String input = mEt_Spelling.getText().toString().trim();
+        String input = mEtSpelling.getText().toString().trim();
         if (input.length() == 0) {
             Toast.makeText(mContext, "Please enter the spelling",
                     Toast.LENGTH_SHORT).show();
@@ -271,7 +271,7 @@ public class MainFragment extends Fragment
         } else {
             mAlert.dismiss();
 
-            String answered = mEt_Spelling.getText().toString().trim();
+            String answered = mEtSpelling.getText().toString().trim();
             db.markAnswered(Integer.parseInt(spell), answered);
 
             Bundle arguments = new Bundle();

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/ResponseFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/ResponseFragment.java
@@ -105,11 +105,11 @@ public class ResponseFragment extends Fragment
             spellId = extras.getString(Intent.EXTRA_TEXT);
         }
 
-        Cursor spell_cursor = db.getSpellingCursorById(Integer.parseInt(spellId));
-        spell_cursor.moveToFirst();
-        String word = spell_cursor.getString(Constants.COL_WORD);
-        String meaning = spell_cursor.getString(Constants.COL_MEANING);
-        String answered = spell_cursor.getString(Constants.COL_ANSWERED);
+        Cursor spellCursor = db.getSpellingCursorById(Integer.parseInt(spellId));
+        spellCursor.moveToFirst();
+        String word = spellCursor.getString(Constants.COL_WORD);
+        String meaning = spellCursor.getString(Constants.COL_MEANING);
+        String answered = spellCursor.getString(Constants.COL_ANSWERED);
 
 
         Menu m = navigationView.getMenu();
@@ -140,24 +140,24 @@ public class ResponseFragment extends Fragment
         MenuItem mi = m.getItem(m.size() - 1);
         mi.setTitle(mi.getTitle());
 
-        TextView mTv_WordNumber = (TextView) rootView.findViewById(R.id.intro_number);
+        TextView mTvWordNumber = (TextView) rootView.findViewById(R.id.intro_number);
 
-        mTv_WordNumber.setText(String.format(Locale.ENGLISH, "Word #%d of %d", Integer.parseInt(spellId), numQues));
+        mTvWordNumber.setText(String.format(Locale.ENGLISH, "Word #%d of %d", Integer.parseInt(spellId), numQues));
 
         String message;
-        String word_text_view;
+        String wordTextView;
         if (word.trim().equalsIgnoreCase(answered)) {
             message = "Great! You got it right.";
-            word_text_view = "Correct Spell: &nbsp<font color='green'>" + word + "</font>";
+            wordTextView = "Correct Spell: &nbsp<font color='green'>" + word + "</font>";
         } else {
             message = "Oops! You got it wrong.";
-            word_text_view = "Correct Spell:&nbsp <font color=\"#7fe77f\">" + word + "</font> <br />You entered:&nbsp <font color=\"#ee9797\">" + answered + "</font>";
+            wordTextView = "Correct Spell:&nbsp <font color=\"#7fe77f\">" + word + "</font> <br />You entered:&nbsp <font color=\"#ee9797\">" + answered + "</font>";
         }
 
         assert rootView.findViewById(R.id.intro_response) != null;
         ((TextView) rootView.findViewById(R.id.intro_response)).setText(message);
         assert rootView.findViewById(R.id.word) != null;
-        ((TextView) rootView.findViewById(R.id.word)).setText(Html.fromHtml(word_text_view), TextView.BufferType.SPANNABLE);
+        ((TextView) rootView.findViewById(R.id.word)).setText(Html.fromHtml(wordTextView), TextView.BufferType.SPANNABLE);
 
         assert rootView.findViewById(R.id.meaning) != null;
         ((TextView) rootView.findViewById(R.id.meaning)).setText(meaning);

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/learnspelling/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.main_title_spell));
 
         rootView.findViewById(R.id.enter).setOnClickListener(new View.OnClickListener() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/data/FetchXMLTask.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/data/FetchXMLTask.java
@@ -56,18 +56,18 @@ public class FetchXMLTask extends AsyncTask<String, Void, Void> {
     private void saveMetaData(MatchMetaModel metaDetails) {
 
         String title;
-        String first_list_title;
-        String second_list_title;
+        String firstListTitle;
+        String secondListTitle;
 
         title = metaDetails.getTitle();
-        first_list_title = metaDetails.getFirstListTitle();
-        second_list_title = metaDetails.getSecondListTitle();
+        firstListTitle = metaDetails.getFirstListTitle();
+        secondListTitle = metaDetails.getSecondListTitle();
 
         ContentValues metaValues = new ContentValues();
 
         metaValues.put(MetaDetails.TITLE, title);
-        metaValues.put(MetaDetails.FIRST_TITLE_TAG, first_list_title);
-        metaValues.put(MetaDetails.SECOND_TITLE_TAG, second_list_title);
+        metaValues.put(MetaDetails.FIRST_TITLE_TAG, firstListTitle);
+        metaValues.put(MetaDetails.SECOND_TITLE_TAG, secondListTitle);
 
         MatchDb db = new MatchDb(mContext);
         db.open();
@@ -121,11 +121,11 @@ public class FetchXMLTask extends AsyncTask<String, Void, Void> {
             doc.normalize();
             mList = new ArrayList<>();
 
-            String match_title = doc.getElementsByTagName(MatchMetaModel.TITLE_TAG).item(0).getTextContent();
-            String first_list_title = doc.getElementsByTagName(MatchMetaModel.FIRST_TITLE_TAG).item(0).getTextContent();
-            String second_list_title = doc.getElementsByTagName(MatchMetaModel.SECOND_TITLE_TAG).item(0).getTextContent();
+            String matchTitle = doc.getElementsByTagName(MatchMetaModel.TITLE_TAG).item(0).getTextContent();
+            String firstListTitle = doc.getElementsByTagName(MatchMetaModel.FIRST_TITLE_TAG).item(0).getTextContent();
+            String secondListTitle = doc.getElementsByTagName(MatchMetaModel.SECOND_TITLE_TAG).item(0).getTextContent();
 
-            saveMetaData(new MatchMetaModel(match_title, first_list_title, second_list_title));
+            saveMetaData(new MatchMetaModel(matchTitle, firstListTitle, secondListTitle));
 
             NodeList childNodes = doc.getElementsByTagName("item");
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/data/MatchMetaModel.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/data/MatchMetaModel.java
@@ -28,19 +28,19 @@ public class MatchMetaModel implements Parcelable {
         }
     };
     private final String title;
-    private final String first_list_title;
-    private final String second_list_title;
+    private final String firstListTitle;
+    private final String secondListTitle;
 
     public MatchMetaModel(String t, String A, String B) {
         this.title = t;
-        this.first_list_title = A;
-        this.second_list_title = B;
+        this.firstListTitle = A;
+        this.secondListTitle = B;
     }
 
     private MatchMetaModel(Parcel in) {
         this.title = in.readString();
-        this.first_list_title = in.readString();
-        this.second_list_title = in.readString();
+        this.firstListTitle = in.readString();
+        this.secondListTitle = in.readString();
     }
 
     @Override
@@ -51,16 +51,16 @@ public class MatchMetaModel implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(title);
-        dest.writeString(first_list_title);
-        dest.writeString(second_list_title);
+        dest.writeString(firstListTitle);
+        dest.writeString(secondListTitle);
     }
 
     public String getFirstListTitle() {
-        return first_list_title;
+        return firstListTitle;
     }
 
     public String getSecondListTitle() {
-        return second_list_title;
+        return secondListTitle;
     }
 
     public String getTitle() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/matchtemplate/fragment/SplashFragment.java
@@ -39,10 +39,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.match_title));
 
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/data/QuizDb.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/data/QuizDb.java
@@ -79,11 +79,11 @@ public class QuizDb {
             Cursor cursor = getQuestionCursorById(i);
             cursor.moveToFirst();
 
-            String correct_answer = cursor.getString(Constants.COL_CORRECT_ANSWER);
+            String correctAnswer = cursor.getString(Constants.COL_CORRECT_ANSWER);
             int attempted = cursor.getInt(Constants.COL_ATTEMPTED);
             if (attempted == 1) {
                 String answer = cursor.getString(Constants.COL_ANSWERED);
-                if (answer.equals(correct_answer)) {
+                if (answer.equals(correctAnswer)) {
                     stat[0]++;
                 } else {
                     stat[1]++;

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/fragment/QuestionFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/fragment/QuestionFragment.java
@@ -100,10 +100,10 @@ public class QuestionFragment extends Fragment
         Cursor cursor = db.getQuestionCursorById(Integer.parseInt(questionId));
         cursor.moveToFirst();
         String question = cursor.getString(Constants.COL_QUESTION);
-        String option_1 = cursor.getString(Constants.COL_OPTION_1);
-        String option_2 = cursor.getString(Constants.COL_OPTION_2);
-        String option_3 = cursor.getString(Constants.COL_OPTION_3);
-        String option_4 = cursor.getString(Constants.COL_OPTION_4);
+        String optionOne = cursor.getString(Constants.COL_OPTION_1);
+        String optionTwo = cursor.getString(Constants.COL_OPTION_2);
+        String optionThree = cursor.getString(Constants.COL_OPTION_3);
+        String optionFour = cursor.getString(Constants.COL_OPTION_4);
         int attempted = cursor.getInt(Constants.COL_ATTEMPTED);
         String answered;
 
@@ -152,21 +152,21 @@ public class QuestionFragment extends Fragment
 
         ((TextView) rootView.findViewById(R.id.question_title)).setText(String.format(Locale.getDefault(), getString(R.string.quiz_question_no), questionId));
         ((TextView) rootView.findViewById(R.id.question)).setText(question);
-        if (option_1 != null) {
+        if (optionOne != null) {
             rootView.findViewById(R.id.radioButton1).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton1)).setText(option_1);
+            ((TextView) rootView.findViewById(R.id.radioButton1)).setText(optionOne);
         }
-        if (option_2 != null) {
+        if (optionTwo != null) {
             rootView.findViewById(R.id.radioButton2).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton2)).setText(option_2);
+            ((TextView) rootView.findViewById(R.id.radioButton2)).setText(optionTwo);
         }
-        if (option_3 != null) {
+        if (optionThree != null) {
             rootView.findViewById(R.id.radioButton3).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton3)).setText(option_3);
+            ((TextView) rootView.findViewById(R.id.radioButton3)).setText(optionThree);
         }
-        if (option_4 != null) {
+        if (optionFour != null) {
             rootView.findViewById(R.id.radioButton4).setVisibility(View.VISIBLE);
-            ((TextView) rootView.findViewById(R.id.radioButton4)).setText(option_4);
+            ((TextView) rootView.findViewById(R.id.radioButton4)).setText(optionFour);
         }
 
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/quiztemplate/fragment/SplashFragment.java
@@ -40,10 +40,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.app_name_quiz));
 
 

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/MatchTemplate.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/MatchTemplate.java
@@ -40,28 +40,28 @@ public class MatchTemplate implements TemplateInterface {
         metaData = new ArrayList<>();
     }
 
-    private static boolean validated(Context context, EditText title, EditText first_list_title, EditText second_list_title) {
-        if (title == null || first_list_title == null || second_list_title == null) {
+    private static boolean validated(Context context, EditText title, EditText firstListTitle, EditText secondListTitle) {
+        if (title == null || firstListTitle == null || secondListTitle == null) {
             return false;
         }
 
         String titleText = title.getText().toString().trim();
-        String first_list_titleText = first_list_title.getText().toString().trim();
-        String second_list_titleText = second_list_title.getText().toString().trim();
+        String firstListTitleText = firstListTitle.getText().toString().trim();
+        String secondListTitleText = secondListTitle.getText().toString().trim();
 
         if ("".equals(titleText)) {
             title.hasFocus();
             title.setError(context.getString(R.string.match_main_title));
             return false;
-        } else if ("".equals(first_list_titleText)) {
-            first_list_title.hasFocus();
-            first_list_title.setError(context.getString(R.string.match_first_list_title));
+        } else if ("".equals(firstListTitleText)) {
+            firstListTitle.hasFocus();
+            firstListTitle.setError(context.getString(R.string.match_first_list_title));
             return false;
-        } else if ("".equals(second_list_titleText)) {
-            second_list_title.hasFocus();
-            second_list_title.setError(context.getString(R.string.match_second_list_title));
+        } else if ("".equals(secondListTitleText)) {
+            secondListTitle.hasFocus();
+            secondListTitle.setError(context.getString(R.string.match_second_list_title));
             return false;
-        } else if (first_list_titleText.equalsIgnoreCase(second_list_titleText)){
+        } else if (firstListTitleText.equalsIgnoreCase(secondListTitleText)){
             Toast.makeText(context, "Title of two lists cannot be same.", Toast.LENGTH_SHORT).show();
             return false;
         }
@@ -69,23 +69,23 @@ public class MatchTemplate implements TemplateInterface {
         return true;
     }
 
-    private static boolean validated(Context context, EditText first_list_title, EditText second_list_title) {
-        if (first_list_title == null || second_list_title == null) {
+    private static boolean validated(Context context, EditText firstListTitle, EditText secondListTitle) {
+        if (firstListTitle == null || secondListTitle == null) {
             return false;
         }
 
-        String first_list_titleText = first_list_title.getText().toString().trim();
-        String second_list_titleText = second_list_title.getText().toString().trim();
+        String firstListTitleText = firstListTitle.getText().toString().trim();
+        String secondListTitleText = secondListTitle.getText().toString().trim();
 
-        if (first_list_titleText.equals("")) {
-            first_list_title.hasFocus();
-            first_list_title.setError(context.getString(R.string.match_first_list_title));
+        if (firstListTitleText.equals("")) {
+            firstListTitle.hasFocus();
+            firstListTitle.setError(context.getString(R.string.match_first_list_title));
             return false;
-        } else if (second_list_titleText.equals("")) {
-            second_list_title.hasFocus();
-            second_list_title.setError(context.getString(R.string.match_second_list_title));
+        } else if (secondListTitleText.equals("")) {
+            secondListTitle.hasFocus();
+            secondListTitle.setError(context.getString(R.string.match_second_list_title));
             return false;
-        } else if (second_list_titleText.equals(first_list_titleText)){
+        } else if (secondListTitleText.equals(firstListTitleText)){
             Toast.makeText(context, "Two options cannot be same.", Toast.LENGTH_SHORT).show();
             return false;
         }
@@ -131,9 +131,9 @@ public class MatchTemplate implements TemplateInterface {
     public BaseAdapter loadProjectMetaEditor(Context context, Document doc) {
 
         String title = doc.getElementsByTagName(MatchMetaModel.TITLE_TAG).item(0).getTextContent();
-        String first_list_title = doc.getElementsByTagName(MatchMetaModel.FIRST_TITLE_TAG).item(0).getTextContent();
-        String second_list_title = doc.getElementsByTagName(MatchMetaModel.SECOND_TITLE_TAG).item(0).getTextContent();
-        metaData.add(new MatchMetaModel(title, first_list_title, second_list_title));
+        String firstListTitle = doc.getElementsByTagName(MatchMetaModel.FIRST_TITLE_TAG).item(0).getTextContent();
+        String secondListTitle = doc.getElementsByTagName(MatchMetaModel.SECOND_TITLE_TAG).item(0).getTextContent();
+        metaData.add(new MatchMetaModel(title, firstListTitle, secondListTitle));
         metaAdapter = new MatchMetaAdapter(context, metaData);
         setEmptyView((Activity) context);
 
@@ -214,19 +214,19 @@ public class MatchTemplate implements TemplateInterface {
         dialog.show();
 
         final EditText title = (EditText) dialogView.findViewById(R.id.meta_title);
-        final EditText first_list_title = (EditText) dialogView.findViewById(R.id.meta_first_list_title);
-        final EditText second_list_title = (EditText) dialogView.findViewById(R.id.meta_second_list_title);
+        final EditText firstListTitle = (EditText) dialogView.findViewById(R.id.meta_first_list_title);
+        final EditText secondListTitle = (EditText) dialogView.findViewById(R.id.meta_second_list_title);
 
         dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
 
-                if (validated(activity, title, first_list_title, second_list_title)) {
+                if (validated(activity, title, firstListTitle, secondListTitle)) {
 
                     String titleText = title.getText().toString().trim();
-                    String first_list_titleText = first_list_title.getText().toString().trim();
-                    String second_list_titleText = second_list_title.getText().toString().trim();
-                    MatchMetaModel temp = new MatchMetaModel(titleText, first_list_titleText, second_list_titleText);
+                    String firstListTitleText = firstListTitle.getText().toString().trim();
+                    String secondListTitleText = secondListTitle.getText().toString().trim();
+                    MatchMetaModel temp = new MatchMetaModel(titleText, firstListTitleText, secondListTitleText);
                     metaData.add(temp);
                     setEmptyView(activity);
                     metaAdapter.notifyDataSetChanged();
@@ -255,26 +255,26 @@ public class MatchTemplate implements TemplateInterface {
             final MatchMetaModel data = metaData.get(0);
 
             final EditText title = (EditText) dialogView.findViewById(R.id.meta_title);
-            final EditText first_list_title = (EditText) dialogView.findViewById(R.id.meta_first_list_title);
-            final EditText second_list_title = (EditText) dialogView.findViewById(R.id.meta_second_list_title);
+            final EditText firstListTitle = (EditText) dialogView.findViewById(R.id.meta_first_list_title);
+            final EditText secondListTitle = (EditText) dialogView.findViewById(R.id.meta_second_list_title);
 
             title.setText(data.getTitle().trim());
-            first_list_title.setText(data.getFirstListTitle().trim());
-            second_list_title.setText(data.getSecondListTitle().trim());
+            firstListTitle.setText(data.getFirstListTitle().trim());
+            secondListTitle.setText(data.getSecondListTitle().trim());
 
             dialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View v) {
 
-                    if (validated(activity, title, first_list_title, second_list_title)) {
+                    if (validated(activity, title, firstListTitle, secondListTitle)) {
 
                         String titleText = title.getText().toString().trim();
-                        String first_list_titleText = first_list_title.getText().toString().trim();
-                        String second_list_titleText = second_list_title.getText().toString().trim();
+                        String firstListTitleText = firstListTitle.getText().toString().trim();
+                        String secondListTitleText = secondListTitle.getText().toString().trim();
 
                         data.setTitle(titleText);
-                        data.setFirstListTitle(first_list_titleText);
-                        data.setSecond_list_title(second_list_titleText);
+                        data.setFirstListTitle(firstListTitleText);
+                        data.setSecond_list_title(secondListTitleText);
                         metaAdapter.notifyDataSetChanged();
                         dialog.dismiss();
                     }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/VideoModel.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/templates/VideoModel.java
@@ -20,13 +20,13 @@ public class VideoModel implements Serializable {
     private String title;
     private String description;
     private String link;
-    private String thumbnail_url;
+    private String thumbnailUrl;
 
-    public VideoModel(String title, String description, String link, String thumbnail_url) {
+    public VideoModel(String title, String description, String link, String thumbnailUrl) {
         this.title = title;
         this.description = description;
         this.link = link;
-        this.thumbnail_url = thumbnail_url;
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     public String getTitle() {
@@ -46,11 +46,11 @@ public class VideoModel implements Serializable {
     }
 
     public String getThumbnailUrl() {
-        return thumbnail_url;
+        return thumbnailUrl;
     }
 
-    public void setThumbnailUrl(String thumbnail_url) {
-        this.thumbnail_url = thumbnail_url;
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     public String getLink() {
@@ -73,7 +73,7 @@ public class VideoModel implements Serializable {
         linkElement.appendChild(doc.createTextNode(String.valueOf(link)));
         rootElement.appendChild(linkElement);
         Element videoLinkElement = doc.createElement(THUMB_LINK_TAG);
-        videoLinkElement.appendChild(doc.createTextNode(String.valueOf(thumbnail_url)));
+        videoLinkElement.appendChild(doc.createTextNode(String.valueOf(thumbnailUrl)));
         rootElement.appendChild(videoLinkElement);
         return rootElement;
     }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/adapter/VideoArrayAdapter.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/adapter/VideoArrayAdapter.java
@@ -43,11 +43,11 @@ public class VideoArrayAdapter extends CursorAdapter {
     public void bindView(View view, final Context context, Cursor cursor) {
         final ViewHolder viewHolder = (ViewHolder) view.getTag();
 
-        final String thumb_url = cursor.getString(Constants.COL_THUMBNAIL_URL);
+        final String thumbUrl = cursor.getString(Constants.COL_THUMBNAIL_URL);
 
         Picasso
                 .with(context)
-                .load(thumb_url)
+                .load(thumbUrl)
                 .transform(new RoundedTransformation(10, 10))
                 .fit()
                 .centerCrop()
@@ -61,7 +61,7 @@ public class VideoArrayAdapter extends CursorAdapter {
                     public void onError() {
                         Picasso
                                 .with(context)
-                                .load(thumb_url)
+                                .load(thumbUrl)
                                 .error(R.mipmap.ic_launcher)
                                 .fit()
                                 .centerCrop()

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/data/FetchXMLTask.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/data/FetchXMLTask.java
@@ -59,21 +59,21 @@ public class FetchXMLTask extends AsyncTask<String, Void, Void> {
             String title;
             String description;
             String link;
-            String thumbnail_url;
+            String thumbnailUrl;
 
             VideoModel videoInfo = videos.get(i);
 
             title = videoInfo.getTitle();
             description = videoInfo.getDescription();
             link = videoInfo.getLink();
-            thumbnail_url = videoInfo.getThumbnailUrl();
+            thumbnailUrl = videoInfo.getThumbnailUrl();
 
             ContentValues videoValues = new ContentValues();
 
             videoValues.put(VideoContract.Videos.TITLE, title);
             videoValues.put(VideoContract.Videos.DESCRIPTION, description);
             videoValues.put(VideoContract.Videos.LINK, link);
-            videoValues.put(VideoContract.Videos.THUMBNAIL_URL, thumbnail_url);
+            videoValues.put(VideoContract.Videos.THUMBNAIL_URL, thumbnailUrl);
 
             cVVector.add(videoValues);
         }

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/data/VideoModel.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/data/VideoModel.java
@@ -24,7 +24,7 @@ public class VideoModel implements Parcelable {
     private String title;
     private String description;
     private String link;
-    private String thumbnail_url;
+    private String thumbnailUrl;
 
     public VideoModel() {
     }
@@ -33,7 +33,7 @@ public class VideoModel implements Parcelable {
         this.title = in.readString();
         this.description = in.readString();
         this.link = in.readString();
-        this.thumbnail_url = in.readString();
+        this.thumbnailUrl = in.readString();
     }
 
     @Override
@@ -46,7 +46,7 @@ public class VideoModel implements Parcelable {
         dest.writeString(title);
         dest.writeString(description);
         dest.writeString(link);
-        dest.writeString(thumbnail_url);
+        dest.writeString(thumbnailUrl);
     }
 
     public String getTitle() {
@@ -66,11 +66,11 @@ public class VideoModel implements Parcelable {
     }
 
     public String getThumbnailUrl() {
-        return thumbnail_url;
+        return thumbnailUrl;
     }
 
-    public void setThumbnailUrl(String thumbnail_url) {
-        this.thumbnail_url = thumbnail_url;
+    public void setThumbnailUrl(String thumbnailUrl) {
+        this.thumbnailUrl = thumbnailUrl;
     }
 
     public String getLink() {

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/fragment/DetailActivityFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/fragment/DetailActivityFragment.java
@@ -36,7 +36,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
     private View rootView;
     private WebView player;
-    private String video_Id;
+    private String videoId;
     private VideoDb db;
 
     public DetailActivityFragment() {
@@ -52,7 +52,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                              Bundle savedInstanceState) {
         Bundle arguments = getArguments();
         if (arguments != null) {
-            video_Id = arguments.getString(Intent.EXTRA_TEXT);
+            videoId = arguments.getString(Intent.EXTRA_TEXT);
         }
         rootView = inflater.inflate(R.layout.fragment_detail_video, container, false);
 
@@ -106,14 +106,14 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
     @Override
     public Loader<Cursor> onCreateLoader(int id, Bundle args) {
-        if (null != video_Id) {
+        if (null != videoId) {
             switch (id) {
                 case DETAIL_LOADER:
 
                     return new CursorLoader(getActivity(), null, Constants.VIDEO_COLUMNS, null, null, null) {
                         @Override
                         public Cursor loadInBackground() {
-                            return db.getVideoCursorById(Integer.parseInt(video_Id));
+                            return db.getVideoCursorById(Integer.parseInt(videoId));
                         }
                     };
                 default: //do nothing
@@ -205,7 +205,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
 
                     long numColumns = db.getCount();
 
-                    long nextVideoId = Integer.parseInt(video_Id) + 1;
+                    long nextVideoId = Integer.parseInt(videoId) + 1;
 
                     if (nextVideoId <= numColumns) {
 
@@ -222,7 +222,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                 }
             });
 
-            if (Integer.parseInt(video_Id) == 1) {
+            if (Integer.parseInt(videoId) == 1) {
 
                 rootView.findViewById(R.id.previous).setVisibility(View.INVISIBLE);
 
@@ -232,7 +232,7 @@ public class DetailActivityFragment extends Fragment implements LoaderCallbacks<
                     @Override
                     public void onClick(View v) {
 
-                        int prevVideoId = Integer.parseInt(video_Id) - 1;
+                        int prevVideoId = Integer.parseInt(videoId) - 1;
 
                         if (prevVideoId >= 1) {
                             Bundle arguments = new Bundle();

--- a/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/fragment/SplashFragment.java
+++ b/source-code/app/src/main/java/org/buildmlearn/toolkit/videocollectiontemplate/fragment/SplashFragment.java
@@ -37,10 +37,10 @@ public class SplashFragment extends Fragment {
         final Activity mActivity = getActivity();
         final String result[] = DataUtils.readTitleAuthor();
         TextView title = (TextView) rootView.findViewById(R.id.title);
-        TextView author_name = (TextView) rootView.findViewById(R.id.author_name);
+        TextView authorName = (TextView) rootView.findViewById(R.id.author_name);
 
         title.setText(result[0]);
-        author_name.setText(result[1]);
+        authorName.setText(result[1]);
         ((TextViewPlus) rootView.findViewById(R.id.intro_text)).setText(getResources().getString(R.string.video_collection_title));
 
         rootView.findViewById(R.id.enter).setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
Many classes were having variable names in lower case with hyphens, as stated in #328 .

 This PR changes them to `lowerCamelCase` which is standard convention for naming variables in Java.